### PR TITLE
Updated homepage: s/input-filter/inputfilter/

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "zf2",
         "inputfilter"
     ],
-    "homepage": "https://github.com/zendframework/zend-input-filter",
+    "homepage": "https://github.com/zendframework/zend-inputfilter",
     "autoload": {
         "psr-4": {
             "Zend\\InputFilter\\": "src/"


### PR DESCRIPTION
This fixes the homepage reference in the `composer.json` to reference the github repository correctly.