### PR TITLE
Change to InputFilterFactory and CollectionInputFilter to support nested input-filter config

### DIFF
--- a/src/InputFilterAbstractServiceFactory.php
+++ b/src/InputFilterAbstractServiceFactory.php
@@ -81,6 +81,8 @@ class InputFilterAbstractServiceFactory implements AbstractFactoryInterface
             ->getDefaultValidatorChain()
             ->setPluginManager($this->getValidatorPluginManager($services));
 
+        $this->factory->setInputFilterManager($services->get('InputFilterManager'));
+
         return $this->factory;
     }
 

--- a/src/InputFilterPluginManager.php
+++ b/src/InputFilterPluginManager.php
@@ -61,8 +61,16 @@ class InputFilterPluginManager extends AbstractPluginManager
             $factory->setInputFilterManager($this);
 
             if ($this->serviceLocator instanceof ServiceLocatorInterface) {
-                $factory->getDefaultFilterChain()->setPluginManager($this->serviceLocator->get('FilterManager'));
-                $factory->getDefaultValidatorChain()->setPluginManager($this->serviceLocator->get('ValidatorManager'));
+                if ($this->serviceLocator->has('FilterManager')) {
+                    $factory->getDefaultFilterChain()->setPluginManager(
+                        $this->serviceLocator->get('FilterManager')
+                    );
+                }
+                if ($this->serviceLocator->has('ValidatorManager')) {
+                    $factory->getDefaultValidatorChain()->setPluginManager(
+                        $this->serviceLocator->get('ValidatorManager')
+                    );
+                }
             }
         }
     }

--- a/test/InputFilterAbstractServiceFactoryTest.php
+++ b/test/InputFilterAbstractServiceFactoryTest.php
@@ -11,6 +11,7 @@ namespace ZendTest\InputFilter;
 
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Filter\FilterPluginManager;
+use Zend\InputFilter\InputFilter;
 use Zend\InputFilter\InputFilterPluginManager;
 use Zend\ServiceManager\ServiceManager;
 use Zend\Validator\ValidatorPluginManager;
@@ -153,4 +154,30 @@ class InputFilterAbstractServiceFactoryTest extends TestCase
         $inputFilter = $this->services->get('InputFilterManager')->get('foobar');
         $this->assertInstanceOf('Zend\InputFilter\InputFilterInterface', $inputFilter);
     }
+
+
+    /**
+     * @depends testCreatesInputFilterInstance
+     */
+    public function testInjectsInputFilterManagerFromServiceManager()
+    {
+        $this->services->setService('Config', array(
+            'input_filter_specs' => array(
+                'filter' => array(),
+            ),
+        ));
+        $this->filters->addAbstractFactory('ZendTest\InputFilter\TestAsset\FooAbstractFactory');
+
+        /**
+         * @type InputFilter $filter
+         */
+        $filter = $this->factory->createServiceWithName($this->filters, 'filter', 'filter');
+
+        $inputFilterManager = $filter->getFactory()->getInputFilterManager();
+
+        $this->assertInstanceOf('Zend\InputFilter\InputFilterPluginManager', $inputFilterManager);
+
+        $this->assertInstanceOf('ZendTest\InputFilter\TestAsset\Foo', $inputFilterManager->get('foo'));
+    }
+
 }

--- a/test/TestAsset/Foo.php
+++ b/test/TestAsset/Foo.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\InputFilter\TestAsset;
+
+use Zend\InputFilter\BaseInputFilter;
+
+class Foo extends BaseInputFilter
+{
+}

--- a/test/TestAsset/FooAbstractFactory.php
+++ b/test/TestAsset/FooAbstractFactory.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\InputFilter\TestAsset;
+
+use Zend\ServiceManager\AbstractFactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class FooAbstractFactory implements AbstractFactoryInterface
+{
+    public function canCreateServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
+    {
+        if ($name == 'foo') {
+            return true;
+        }
+    }
+    public function createServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
+    {
+        return new Foo;
+    }
+}


### PR DESCRIPTION
I've had some difficulty implementing InputFilterFactory via array config when needing to implement nested CollectionInputFilter; Specifically when using zf-content-validation.

My use case is such that input will have nested entities (and associated input filter configurations), and my problems arose from having to explicitly re-define/duplicate the validators because the base InputFilterPluginManager was not available downstream.

I'm suggesting the following changes that I've made to resolve this:
1. Added the InputFilterPluginManager to new InputFilterFactory instances created via the Input Filter Abstract Service Factory.
2. Added functionality to retrieve nested InputFilters on the CollectionInputFilter via the Service Manager if available (allowing for nested InputFilter configurations).

I encourage feedback and will be happy to re-work as needed as there may be a reason the InputFilterManager wasn't supplied in the factory initially.