### PR TITLE
Problems working with allowEmpty & required

### DIFF
--- a/test/BaseInputFilterTest.php
+++ b/test/BaseInputFilterTest.php
@@ -641,8 +641,10 @@ class BaseInputFilterTest extends TestCase
     /**
      * @dataProvider contextDataProvider()
      */
+    // @codingStandardsIgnoreStart
     public function testValidationMarksInputValidWhenAllowEmptyFlagIsTrueAndContinueIfEmptyIsTrueAndContextValidatesEmptyField($allowEmpty, $blankIsValid, $valid)
     {
+        // @codingStandardsIgnoreEnd
         $filter = new InputFilter();
 
         $data = [
@@ -963,5 +965,59 @@ class BaseInputFilterTest extends TestCase
                ->setData(['foo' => 'nonempty']);
 
         $this->assertFalse($filter->isValid());
+    }
+
+    /**
+     * @group 7
+     */
+    public function testMissingRequiredAllowedEmptyValueShouldMarkInputFilterInvalid()
+    {
+        $foo = new Input('foo');
+        $foo->setRequired(true);
+        $foo->setAllowEmpty(false);
+
+        $bar = new Input('bar');
+        $bar->setRequired(true);
+        $bar->setAllowEmpty(true);
+
+        $filter = new InputFilter();
+        $filter->add($foo);
+        $filter->add($bar);
+
+        $filter->setData(['foo' => 'xyz']);
+        $this->assertFalse($filter->isValid(), 'Missing required value should mark input filter as invalid');
+    }
+
+    public function emptyValuesForValidation()
+    {
+        return [
+            'null'         => [null],
+            'empty-string' => [''],
+        ];
+    }
+
+    /**
+     * @group 7
+     * @dataProvider emptyValuesForValidation
+     */
+    public function testEmptyValuePassedForRequiredButAllowedEmptyInputShouldMarkInputFilterValid($value)
+    {
+        $foo = new Input('foo');
+        $foo->setRequired(true);
+        $foo->setAllowEmpty(false);
+
+        $bar = new Input('bar');
+        $bar->setRequired(true);
+        $bar->setAllowEmpty(true);
+
+        $filter = new InputFilter();
+        $filter->add($foo);
+        $filter->add($bar);
+
+        $filter->setData([
+            'foo' => 'xyz',
+            'bar' => $value,
+        ]);
+        $this->assertTrue($filter->isValid(), 'Empty value should mark input filter as valid');
     }
 }

--- a/test/FactoryTest.php
+++ b/test/FactoryTest.php
@@ -655,15 +655,15 @@ class FactoryTest extends TestCase
         $pluginManager->setService('bar', new Input('bar'));
         $factory->setInputFilterManager($pluginManager);
 
-        $input = $factory->createInput(array(
+        $input = $factory->createInput([
             'type' => 'bar'
-        ));
+        ]);
         $this->assertSame('bar', $input->getName());
 
         $this->setExpectedException('Zend\Filter\Exception\RuntimeException');
-        $factory->createInput(array(
+        $factory->createInput([
             'type' => 'foo'
-        ));
+        ]);
     }
 
     public function testInputFromPluginManagerMayBeFurtherConfiguredWithSpec()
@@ -674,10 +674,10 @@ class FactoryTest extends TestCase
         $this->assertTrue($barInput->isRequired());
         $factory->setInputFilterManager($pluginManager);
 
-        $input = $factory->createInput(array(
+        $input = $factory->createInput([
             'type' => 'bar',
             'required' => false
-        ));
+        ]);
 
         $this->assertFalse($input->isRequired());
         $this->assertSame('bar', $input->getName());


### PR DESCRIPTION
Hey there,

I'm trying to get my head around using Zend\InputFilter for validation. I don't use the library with Zend\Form, I try to use it for API backend data validation and filtering. In this setup we have POST data coming from outside and I would like to validate this against business rules.

Let's say, I have the attribute `foo`, which is required and allow_empty is false and I have `bar`, which is required, but needs allow_empty true, to be able to set an empty string as value. Doing it this way, isValid returns false, if I do not provide any `foo` key inside the array I provide with setData call. This is what I expect, everything finet.

But if I provided a valid `foo` attribute and I do not provide any `bar` key inside the data array, the isValid call will return true. What I would expect: failing like the first test, because the key `bar` is completly missing.

I do know, that there were many changes around isRequire and allowEmpty in last two releases. Since then we're struggeling with our defined InputFilters and trying to understand, what changes happend and how the logic behind this is thought to work now. I already have read, that the attribute continueIfEmpty is also having a role inside the InputFilter process and it is working for me, that validation rules get processed if I set it to true. 

Digging through the isValid process I recognized, that firing an isValid call is first running through $this->getRawValues(); - after that point, $data array contains `bar` with NULL value, because the data keys are generated out of defined inputFilter. So setting continueIfEmpty to true and adding an own validator to check for existing key inside my data array does not work, because it _does_ exist inside there, being populated through getRawValues call.

So, is there any way to validate provided input for existiting keys with InpuFilter? Or how can I achieve having a fixed requirement of data keys, that need to be provided, or input gets marked as invalid? I would really to avoid extra checks like

    if (!isset($postValues['bar'])) {
        throw new \InvalidArgumentException('Please provide a value for "bar"');
    }

My tests to show, what my problem is.

    class AllowEmptyTest extends \PHPUnit_Framework_TestCase
    {
        public function testInputFilterBeingRequiredAndDataNotProvided()
        {
            $inputFilter = new \Zend\InputFilter\InputFilter();
            $inputFilter->add([
                'name' => 'foo',
                'required' => true,
                'allow_empty' => false,
            ]);
            $inputFilter->add([
                'name' => 'bar',
                'required' => true,
                'allow_empty' => true,
            ]);
    
            $data = [
                'foo2' => 'xyz',
                'bar' => ''
            ];
    
            $inputFilter->setData($data);
    
            $this->assertFalse($inputFilter->isValid());
        }
    
        public function testInputFilterBeingRequiredAndAllowEmptyTrue()
        {
            $inputFilter = new \Zend\InputFilter\InputFilter();
            $inputFilter->add([
                'name' => 'foo',
                'required' => true,
                'allow_empty' => false,
            ]);
            $inputFilter->add([
                'name' => 'bar',
                'required' => true,
                'allow_empty' => true,
            ]);
    
            $data = [
                'foo' => 'xyz'
            ];
    
            $inputFilter->setData($data);
    
            $this->assertFalse($inputFilter->isValid());
        }
    }