### PR TITLE
InputFilter not populating/using FallbackValue for Input

### DIFF
--- a/src/BaseInputFilter.php
+++ b/src/BaseInputFilter.php
@@ -241,13 +241,15 @@ class BaseInputFilter implements
         $valid               = true;
 
         foreach ($inputs as $name) {
-            $input      = $this->inputs[$name];
+            $input       = $this->inputs[$name];
+            $hasFallback = ($input instanceof Input && $input->hasFallback());
 
-            // If the value is required, but not present in the data set,
-            // validation fails.
+            // If the value is required, not present in the data set, and
+            // has no fallback, validation fails.
             if (!array_key_exists($name, $data)
                 && $input instanceof InputInterface
                 && $input->isRequired()
+                && !$hasFallback
             ) {
                 $input->setErrorMessage('Value is required');
                 $this->invalidInputs[$name] = $input;
@@ -257,6 +259,18 @@ class BaseInputFilter implements
                 }
 
                 $valid = false;
+                continue;
+            }
+
+            // If the value is required, not present in the data set, and
+            // has a fallback, validation passes, and we set the input
+            // value to the fallback.
+            if (!array_key_exists($name, $data)
+                && $input instanceof InputInterface
+                && $input->isRequired()
+                && $hasFallback
+            ) {
+                $input->setValue($input->getFallbackValue());
                 continue;
             }
 

--- a/test/BaseInputFilterTest.php
+++ b/test/BaseInputFilterTest.php
@@ -1020,4 +1020,80 @@ class BaseInputFilterTest extends TestCase
         ]);
         $this->assertTrue($filter->isValid(), 'Empty value should mark input filter as valid');
     }
+
+    /**
+     * @group 10
+     */
+    public function testMissingRequiredWithFallbackShouldMarkInputValid()
+    {
+        $foo = new Input('foo');
+        $foo->setRequired(true);
+        $foo->setAllowEmpty(false);
+
+        $bar = new Input('bar');
+        $bar->setRequired(true);
+        $bar->setFallbackValue('baz');
+
+        $filter = new InputFilter();
+        $filter->add($foo);
+        $filter->add($bar);
+
+        $filter->setData(['foo' => 'xyz']);
+        $this->assertTrue($filter->isValid(), 'Missing input with fallback value should mark input filter as valid');
+        $data = $filter->getValues();
+        $this->assertArrayHasKey('bar', $data);
+        $this->assertEquals($bar->getFallbackValue(), $data['bar']);
+    }
+
+    /**
+     * @group 10
+     */
+    public function testMissingRequiredThatAllowsEmptyWithFallbackShouldMarkInputValid()
+    {
+        $foo = new Input('foo');
+        $foo->setRequired(true);
+        $foo->setAllowEmpty(false);
+
+        $bar = new Input('bar');
+        $bar->setRequired(true);
+        $bar->setAllowEmpty(true);
+        $bar->setFallbackValue('baz');
+
+        $filter = new InputFilter();
+        $filter->add($foo);
+        $filter->add($bar);
+
+        $filter->setData(['foo' => 'xyz']);
+        $this->assertTrue($filter->isValid(), 'Missing input with fallback value should mark input filter as valid');
+        $data = $filter->getValues();
+        $this->assertArrayHasKey('bar', $data);
+        $this->assertEquals($bar->getFallbackValue(), $data['bar']);
+    }
+
+    /**
+     * @group 10
+     */
+    public function testEmptyRequiredValueWithFallbackShouldMarkInputValid()
+    {
+        $foo = new Input('foo');
+        $foo->setRequired(true);
+        $foo->setAllowEmpty(false);
+
+        $bar = new Input('bar');
+        $bar->setRequired(true);
+        $bar->setFallbackValue('baz');
+
+        $filter = new InputFilter();
+        $filter->add($foo);
+        $filter->add($bar);
+
+        $filter->setData([
+            'foo' => 'xyz',
+            'bar' => null,
+        ]);
+        $this->assertTrue($filter->isValid(), 'Empty input with fallback value should mark input filter as valid');
+        $data = $filter->getValues();
+        $this->assertArrayHasKey('bar', $data);
+        $this->assertEquals($bar->getFallbackValue(), $data['bar']);
+    }
 }


### PR DESCRIPTION
After updating from Version 2.3.5 to the newest Version i'm running into following error.

I'm creating an new InputFilter creating the Inputs in __construct() like this:

    class ListDataInputFilter extends InputFilter {
        public function __construct() {
            $page = new \Zend\InputFilter\Input('page');
            $page->setFallbackValue(1);
            $this->add($page);
        }
    }

Then i'm calling

    // empty to demonstrate behaviour
    $filterParams = array();
    $filter = new ListDataFilter();
    $filter->setData($filterParams);
    if(!$filter->isValid()) {
        var_dump($filter->getMessages());
    }

With Version 2.3.5 it's worked as expected. Populating the Fallback Value and not throwing an Error. But with 2.5.* instead of filling the Page Input with the Fallback Value it's empty and the Filter is not valid.