### PR TITLE
Argument 2 passed to Zend\InputFilter\BaseInputFilter::validateInputs() must be of the type array, object given

### DIFF
--- a/src/BaseInputFilter.php
+++ b/src/BaseInputFilter.php
@@ -224,12 +224,12 @@ class BaseInputFilter implements
     /**
      * Validate a set of inputs against the current data
      *
-     * @param  array      $inputs
-     * @param  array      $data
+     * @param  array $inputs
+     * @param  array|ArrayAccess $data
      * @param  mixed|null $context
      * @return bool
      */
-    protected function validateInputs(array $inputs, array $data = [], $context = null)
+    protected function validateInputs(array $inputs, $data = [], $context = null)
     {
         // backwards compatibility
         if (empty($data)) {

--- a/test/BaseInputFilterTest.php
+++ b/test/BaseInputFilterTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\InputFilter;
 
+use ArrayObject;
 use PHPUnit_Framework_TestCase as TestCase;
 use stdClass;
 use Zend\InputFilter\Input;
@@ -1095,5 +1096,22 @@ class BaseInputFilterTest extends TestCase
         $data = $filter->getValues();
         $this->assertArrayHasKey('bar', $data);
         $this->assertEquals($bar->getFallbackValue(), $data['bar']);
+    }
+
+    /**
+     * @group 15
+     */
+    public function testAllowsValidatingArrayAccessData()
+    {
+        $filter = new InputFilter();
+        $foo = new Input();
+        $foo->getFilterChain()->attachByName('stringtrim')
+                              ->attachByName('alpha');
+        $foo->getValidatorChain()->attach(new Validator\StringLength(3, 6));
+        $filter->add($foo, 'foo');
+
+        $data = new ArrayObject(['foo' => ' valid ']);
+        $filter->setData($data);
+        $this->assertTrue($filter->isValid());
     }
 }


### PR DESCRIPTION
This issue was introduced between version 2.5.1 and 2.5.3, i've switched back and forth between the two versions and I keep getting this error with 2.5.3 but not with 2.5.1
this happens when i try to validate a simple post data

Catchable fatal error: Argument 2 passed to Zend\InputFilter\BaseInputFilter::validateInputs() must be of the type array, object given, called in C:\crazylister\vendor\zendframework\zend-inputfilter\src\BaseInputFilter.php on line 221 and defined in C:\crazylister\vendor\zendframework\zend-inputfilter\src\BaseInputFilter.php on line 232