### PR TITLE
Remove redundant code

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -212,9 +212,6 @@ class Factory
                     break;
                 case 'required':
                     $input->setRequired($value);
-                    if (isset($inputSpecification['allow_empty'])) {
-                        $input->setAllowEmpty($inputSpecification['allow_empty']);
-                    }
                     break;
                 case 'allow_empty':
                     $input->setAllowEmpty($value);


### PR DESCRIPTION
This code is the same logic present in "case 'allow_empty'" when loop cycle match


FactoryTest::testFactoryWillCreateInputWithSuggestedRequiredFlagAndAlternativeAllowEmptyFlag is the test for this case.