### PR TITLE
Missing required field with fallback does not return input in getValidInput

### DIFF
--- a/test/BaseInputFilterTest.php
+++ b/test/BaseInputFilterTest.php
@@ -1069,6 +1069,8 @@ class BaseInputFilterTest extends TestCase
         $data = $filter->getValues();
         $this->assertArrayHasKey('bar', $data);
         $this->assertEquals($bar->getFallbackValue(), $data['bar']);
+        $this->assertArrayHasKey('bar', $filter->getValidInput());
+        $this->assertArrayNotHasKey('bar', $filter->getInvalidInput());
     }
 
     /**
@@ -1096,6 +1098,8 @@ class BaseInputFilterTest extends TestCase
         $data = $filter->getValues();
         $this->assertArrayHasKey('bar', $data);
         $this->assertEquals($bar->getFallbackValue(), $data['bar']);
+        $this->assertArrayHasKey('bar', $filter->getValidInput());
+        $this->assertArrayNotHasKey('bar', $filter->getInvalidInput());
     }
 
     /**


### PR DESCRIPTION
Test method says `testMissingRequiredThatAllowsEmptyWithFallbackShouldMarkInputValid` but don't assert input is returned in `getValidInput`

Should the input to be returned in `getValidInput` collection?

IMO it should because has a valid status.

Test was introduced in #10