### PR TITLE
Fix missing optional fields should not be validated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,29 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#25](https://github.com/zendframework/zend-inputfilter/pull/25) Fix missing optional fields to be required.
+  BC Break since 2.3.9.
+  For completely fix this you need to setup your inputs as follow.
+
+  ```php
+  $input = new Input();
+  $input->setAllowEmpty(true); // Disable BC Break logic related to treat `null` values as valid empty value instead *not set*.
+  $input->setContinueIfEmpty(true); // Disable BC Break logic related to treat `null` values as valid empty value instead *not set*.  
+  $input->getValidatorChain()->attach(new Zend\Validator\NotEmpty(), /* break chain on failure */ true);
+  ```
+
+  ```php
+  $inputSpecification = [
+    'allow_empty' => true,
+    'continue_if_empty' => true,
+    'validators' => [
+      [
+        'break_chain_on_failure' => true,
+        'name' => 'Zend\\Validator\\NotEmpty',
+      ],
+    ],
+  ];
+  ```
 
 ## 2.5.4 - 2015-08-11
 

--- a/src/BaseInputFilter.php
+++ b/src/BaseInputFilter.php
@@ -256,6 +256,7 @@ class BaseInputFilter implements
 
             $hasFallback = ($input instanceof Input && $input->hasFallback());
 
+            // If input is optional (not required) and value is not set then ignore.
             if (!array_key_exists($name, $data)
                 && !$input->isRequired()
             ) {

--- a/src/BaseInputFilter.php
+++ b/src/BaseInputFilter.php
@@ -231,11 +231,6 @@ class BaseInputFilter implements
      */
     protected function validateInputs(array $inputs, $data = [], $context = null)
     {
-        // backwards compatibility
-        if (empty($data)) {
-            $data = $this->getRawValues();
-        }
-
         $this->validInputs   = [];
         $this->invalidInputs = [];
         $valid               = true;

--- a/src/BaseInputFilter.php
+++ b/src/BaseInputFilter.php
@@ -261,6 +261,12 @@ class BaseInputFilter implements
 
             $hasFallback = ($input instanceof Input && $input->hasFallback());
 
+            if (!array_key_exists($name, $data)
+                && !$input->isRequired()
+            ) {
+                continue;
+            }
+
             // If the value is required, not present in the data set, and
             // has no fallback, validation fails.
             if (!array_key_exists($name, $data)


### PR DESCRIPTION
Prevent the assumption of `null` value to be a synonym of value not set. Null values are valid input values (like JSON object with null values)