### PR TITLE
Deprecate EmptyContextInterface, InputInterface::setAllowEmpty & allowEmpty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,32 @@ All notable changes to this project will be documented in this file, in reverse 
   (previously, it would consider the data set valid, and auto-initialize the
   missing input to `null`).
 
+## 2.4.8 - TBD
+
+### Added
+
+- Nothing.
+
+### Deprecated
+
+- [#26](https://github.com/zendframework/zend-inputfilter/pull/26) Deprecate magic logic for auto attach a NonEmpty
+ validator with breakChainOnFailure = true. Instead append NonEmpty validator when desired.
+
+  ```php
+  $input = new Zend\InputFilter\Input();
+  $input->setContinueIfEmpty(true);
+  $input->setAllowEmpty(true);
+  $input->getValidatorChain()->attach(new Zend\Validator\NotEmpty(), /* break chain on failure */ true);
+  ```
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
 ## 2.4.7 - 2015-08-11
 
 ### Added

--- a/src/EmptyContextInterface.php
+++ b/src/EmptyContextInterface.php
@@ -9,15 +9,22 @@
 
 namespace Zend\InputFilter;
 
+/**
+ * @deprecated 2.4.8 Add Zend\Validator\NotEmpty validator to the ValidatorChain.
+ */
 interface EmptyContextInterface
 {
     /**
+     * @deprecated 2.4.8 Add Zend\Validator\NotEmpty validator to the ValidatorChain and set this to `true`.
+     *
      * @param bool $continueIfEmpty
      * @return self
      */
     public function setContinueIfEmpty($continueIfEmpty);
 
     /**
+     * @deprecated 2.4.8 Add Zend\Validator\NotEmpty validator to the ValidatorChain. Should always return `true`.
+     *
      * @return bool
      */
     public function continueIfEmpty();

--- a/src/FileInput.php
+++ b/src/FileInput.php
@@ -187,6 +187,8 @@ class FileInput extends Input
     }
 
     /**
+     * @deprecated 2.4.8 See note on parent class. Removal does not affect this class.
+     *
      * No-op, NotEmpty validator does not apply for FileInputs.
      * See also: BaseInputFilter::isValid()
      *

--- a/src/Input.php
+++ b/src/Input.php
@@ -19,11 +19,15 @@ class Input implements
     EmptyContextInterface
 {
     /**
+     * @deprecated 2.4.8 Add Zend\Validator\NotEmpty validator to the ValidatorChain.
+     *
      * @var bool
      */
     protected $allowEmpty = false;
 
     /**
+     * @deprecated 2.4.8 Add Zend\Validator\NotEmpty validator to the ValidatorChain.
+     *
      * @var bool
      */
     protected $continueIfEmpty = false;
@@ -49,6 +53,8 @@ class Input implements
     protected $name;
 
     /**
+     * @deprecated 2.4.8 Add Zend\Validator\NotEmpty validator to the ValidatorChain.
+     *
      * @var bool
      */
     protected $notEmptyValidator = false;
@@ -91,6 +97,8 @@ class Input implements
     }
 
     /**
+     * @deprecated 2.4.8 Add Zend\Validator\NotEmpty validator to the ValidatorChain and set this to `true`.
+     *
      * @param  bool $allowEmpty
      * @return Input
      */
@@ -111,6 +119,8 @@ class Input implements
     }
 
     /**
+     * @deprecated 2.4.8 Add Zend\Validator\NotEmpty validator to the ValidatorChain and set this to `true`.
+     *
      * @param bool $continueIfEmpty
      * @return Input
      */
@@ -216,6 +226,8 @@ class Input implements
     }
 
     /**
+     * @deprecated 2.4.8 Add Zend\Validator\NotEmpty validator to the ValidatorChain.
+     *
      * @return bool
      */
     public function allowEmpty()
@@ -232,6 +244,8 @@ class Input implements
     }
 
     /**
+     * @deprecated 2.4.8 Add Zend\Validator\NotEmpty validator to the ValidatorChain. Should always return `true`.
+     *
      * @return bool
      */
     public function continueIfEmpty()
@@ -429,6 +443,8 @@ class Input implements
     }
 
     /**
+     * @deprecated 2.4.8 Add Zend\Validator\NotEmpty validator to the ValidatorChain.
+     *
      * @return void
      */
     protected function injectNotEmptyValidator()

--- a/src/InputInterface.php
+++ b/src/InputInterface.php
@@ -15,6 +15,8 @@ use Zend\Validator\ValidatorChain;
 interface InputInterface
 {
     /**
+     * @deprecated 2.4.8 Add Zend\Validator\NotEmpty validator to the ValidatorChain and set this to `true`.
+     *
      * @param bool $allowEmpty
      * @return self
      */
@@ -69,6 +71,8 @@ interface InputInterface
     public function merge(InputInterface $input);
 
     /**
+     * @deprecated 2.4.8 Add Zend\Validator\NotEmpty validator to the ValidatorChain.
+     *
      * @return bool
      */
     public function allowEmpty();


### PR DESCRIPTION
Deprecate magic logic for auto attach a NonEmpty validator with breakChainOnFailure = true

Instead append NonEmpty validator when desired.

```php
$input = new Zend\InputFilter\Input();
$input->setContinueIfEmpty(true);
$input->setAllowEmpty(true);
$input->getValidatorChain()->attach(new Zend\Validator\NotEmpty(), /* break chain on failure */ true);
```

Close https://github.com/zendframework/zend-inputfilter/issues/12