### PR TITLE
Remove array type for input on InputFilterInterface::add()

### DIFF
--- a/src/InputFilterInterface.php
+++ b/src/InputFilterInterface.php
@@ -19,7 +19,7 @@ interface InputFilterInterface extends Countable
     /**
      * Add an input to the input filter
      *
-     * @param  InputInterface|InputFilterInterface|array $input
+     * @param  InputInterface|InputFilterInterface $input
      * @param  null|string $name Name used to retrieve this input
      * @return InputFilterInterface
      */


### PR DESCRIPTION
array capabilities only exists for InputFilter class but not for their parent BaseInputFilter which is responsible of implement the interface.

People with tools warning about unsafe type should typehint against Zend\InputFilter\InputFilter instead Zend\InputFilter\InputFilterInterface

Reverts:

* zendframework/zf2#2304
* 8fa473579e3cd3ef24765f00bfeb2af152a0ea2a
* 93b9bd0538ce223a1808dd4d03d2d23bc776ac8b