### PR TITLE
Promote HHVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ matrix:
     - php: hhvm 
   allow_failures:
     - php: 7
-    - php: hhvm
 
 notifications:
   irc: "irc.freenode.org#zftalk.dev"


### PR DESCRIPTION
While the test coverage still be low (85%) core lines are covered and should be preserved from future incompatibilities.