### PR TITLE
Test suite improvements

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -30,6 +30,7 @@ $config->fixers(
         'multiple_use',
         'method_argument_space',
         'object_operator',
+        'ordered_use',
         'php_closing_tag',
         'remove_lines_between_uses',
         'short_array_syntax',

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "zendframework/zend-i18n": "~2.5",
         "zendframework/zend-servicemanager": "~2.5",
         "fabpot/php-cs-fixer": "1.7.*",
+        "maks3w/phpunit-methods-trait": "^4.6",
         "phpunit/PHPUnit": "~4.0"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "zendframework/zend-servicemanager": "~2.5",
         "fabpot/php-cs-fixer": "1.7.*",
         "maks3w/phpunit-methods-trait": "^4.6",
-        "phpunit/PHPUnit": "~4.0"
+        "phpunit/PHPUnit": "^4.5"
     },
     "suggest": {
         "zendframework/zend-servicemanager": "To support plugin manager support"

--- a/src/ArrayInput.php
+++ b/src/ArrayInput.php
@@ -50,18 +50,27 @@ class ArrayInput extends Input
      */
     public function isValid($context = null)
     {
-        if (!$this->continueIfEmpty() && !$this->allowEmpty()) {
-            $this->injectNotEmptyValidator();
-        }
+        $allowEmpty = $this->allowEmpty();
+        $continueIfEmpty = $this->continueIfEmpty();
+
         $validator = $this->getValidatorChain();
         $values    = $this->getValue();
         $result    = true;
         foreach ($values as $value) {
             $empty = ($value === null || $value === '' || $value === []);
-            if ($empty && $this->allowEmpty() && !$this->continueIfEmpty()) {
+            if ($empty && $allowEmpty && !$continueIfEmpty) {
                 $result = true;
                 continue;
             }
+
+            // At this point, we need to run validators.
+            // If we do not allow empty and the "continue if empty" flag are
+            // BOTH false, we inject the "not empty" validator into the chain,
+            // which adds that logic into the validation routine.
+            if ($empty && !$allowEmpty) {
+                $this->injectNotEmptyValidator();
+            }
+
             $result = $validator->isValid($value, $context);
             if (!$result) {
                 if ($this->hasFallback()) {

--- a/src/BaseInputFilter.php
+++ b/src/BaseInputFilter.php
@@ -36,7 +36,7 @@ class BaseInputFilter implements
     protected $invalidInputs;
 
     /**
-     * @var array
+     * @var null|string[] Input names
      */
     protected $validationGroup;
 
@@ -514,7 +514,7 @@ class BaseInputFilter implements
     /**
      * Ensure all names of a validation group exist as input in the filter
      *
-     * @param  array $inputs
+     * @param  string[] $inputs Input names
      * @return void
      * @throws Exception\InvalidArgumentException
      */
@@ -630,7 +630,7 @@ class BaseInputFilter implements
     /**
      * Get an array of all inputs
      *
-     * @return array
+     * @return InputInterface[]|InputFilterInterface[]
      */
     public function getInputs()
     {

--- a/src/BaseInputFilter.php
+++ b/src/BaseInputFilter.php
@@ -81,8 +81,8 @@ class BaseInputFilter implements
             throw new Exception\InvalidArgumentException(sprintf(
                 '%s expects an instance of %s or %s as its first argument; received "%s"',
                 __METHOD__,
-                'Zend\InputFilter\InputInterface',
-                'Zend\InputFilter\InputFilterInterface',
+                InputInterface::class,
+                InputFilterInterface::class,
                 (is_object($input) ? get_class($input) : gettype($input))
             ));
         }
@@ -117,8 +117,8 @@ class BaseInputFilter implements
             throw new Exception\InvalidArgumentException(sprintf(
                 '%s expects an instance of %s or %s as its first argument; received "%s"',
                 __METHOD__,
-                'Zend\InputFilter\InputInterface',
-                'Zend\InputFilter\InputFilterInterface',
+                InputInterface::class,
+                InputFilterInterface::class,
                 (is_object($input) ? get_class($input) : gettype($input))
             ));
         }

--- a/src/CollectionInputFilter.php
+++ b/src/CollectionInputFilter.php
@@ -24,12 +24,12 @@ class CollectionInputFilter extends InputFilter
     protected $count = null;
 
     /**
-     * @var array
+     * @var array[]
      */
     protected $collectionValues = [];
 
     /**
-     * @var array
+     * @var array[]
      */
     protected $collectionRawValues = [];
 
@@ -226,7 +226,7 @@ class CollectionInputFilter extends InputFilter
     /**
      * Clear collectionValues
      *
-     * @access public
+     * @return array[]
      */
     public function clearValues()
     {
@@ -236,7 +236,7 @@ class CollectionInputFilter extends InputFilter
     /**
      * Clear collectionRawValues
      *
-     * @access public
+     * @return array[]
      */
     public function clearRawValues()
     {

--- a/src/CollectionInputFilter.php
+++ b/src/CollectionInputFilter.php
@@ -13,27 +13,27 @@ use Traversable;
 
 class CollectionInputFilter extends InputFilter
 {
-    /*
+    /**
      * @var bool
      */
     protected $isRequired = false;
 
-    /*
+    /**
      * @var int
      */
     protected $count = null;
 
-    /*
+    /**
      * @var array
      */
     protected $collectionValues = [];
 
-    /*
+    /**
      * @var array
      */
     protected $collectionRawValues = [];
 
-    /*
+    /**
      * @var array
      */
     protected $collectionMessages = [];

--- a/src/CollectionInputFilter.php
+++ b/src/CollectionInputFilter.php
@@ -60,7 +60,7 @@ class CollectionInputFilter extends InputFilter
             throw new Exception\RuntimeException(sprintf(
                 '%s expects an instance of %s; received "%s"',
                 __METHOD__,
-                'Zend\InputFilter\BaseInputFilter',
+                BaseInputFilter::class,
                 (is_object($inputFilter) ? get_class($inputFilter) : gettype($inputFilter))
             ));
         }

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -219,12 +219,26 @@ class Factory
                     }
                     break;
                 case 'continue_if_empty':
+                    if (!$input instanceof Input) {
+                        throw new Exception\RuntimeException(sprintf(
+                            '%s "continue_if_empty" can only set to inputs of type "%s"',
+                            __METHOD__,
+                            Input::class
+                        ));
+                    }
                     $input->setContinueIfEmpty($inputSpecification['continue_if_empty']);
                     break;
                 case 'error_message':
                     $input->setErrorMessage($value);
                     break;
                 case 'fallback_value':
+                    if (!$input instanceof Input) {
+                        throw new Exception\RuntimeException(sprintf(
+                            '%s "fallback_value" can only set to inputs of type "%s"',
+                            __METHOD__,
+                            Input::class
+                        ));
+                    }
                     $input->setFallbackValue($value);
                     break;
                 case 'break_on_failure':

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -167,7 +167,7 @@ class Factory
             $inputSpecification = ArrayUtils::iteratorToArray($inputSpecification);
         }
 
-        $class = 'Zend\InputFilter\Input';
+        $class = Input::class;
 
         if (isset($inputSpecification['type'])) {
             $class = $inputSpecification['type'];
@@ -193,7 +193,7 @@ class Factory
         if (!$input instanceof InputInterface) {
             throw new Exception\RuntimeException(sprintf(
                 'Input factory expects the "type" to be a class implementing %s; received "%s"',
-                'Zend\InputFilter\InputInterface',
+                InputInterface::class,
                 $class
             ));
         }
@@ -293,7 +293,7 @@ class Factory
             $inputFilterSpecification = ArrayUtils::iteratorToArray($inputFilterSpecification);
         }
 
-        $type = 'Zend\InputFilter\InputFilter';
+        $type = InputFilter::class;
 
         if (isset($inputFilterSpecification['type']) && is_string($inputFilterSpecification['type'])) {
             $type = $inputFilterSpecification['type'];

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -10,7 +10,6 @@
 namespace Zend\InputFilter;
 
 use Traversable;
-use Zend\Filter\Exception;
 use Zend\Filter\FilterChain;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use Zend\Stdlib\ArrayUtils;

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -373,7 +373,7 @@ class Factory
 
     /**
      * @param  ValidatorChain    $chain
-     * @param  array|Traversable $validators
+     * @param  string[]|ValidatorInterface[] $validators
      * @throws Exception\RuntimeException
      * @return void
      */

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -12,10 +12,10 @@ namespace Zend\InputFilter;
 use Traversable;
 use Zend\Filter\Exception;
 use Zend\Filter\FilterChain;
-use Zend\Stdlib\ArrayUtils;
-use Zend\Validator\ValidatorInterface;
-use Zend\Validator\ValidatorChain;
 use Zend\ServiceManager\ServiceLocatorInterface;
+use Zend\Stdlib\ArrayUtils;
+use Zend\Validator\ValidatorChain;
+use Zend\Validator\ValidatorInterface;
 
 class Factory
 {

--- a/src/Input.php
+++ b/src/Input.php
@@ -354,7 +354,7 @@ class Input implements
     }
 
     /**
-     * @return array
+     * @return string[]
      */
     public function getMessages()
     {

--- a/src/Input.php
+++ b/src/Input.php
@@ -325,15 +325,10 @@ class Input implements
     {
         $value           = $this->getValue();
         $empty           = ($value === null || $value === '' || $value === []);
-        $required        = $this->isRequired();
         $allowEmpty      = $this->allowEmpty();
         $continueIfEmpty = $this->continueIfEmpty();
 
-        if ($empty && ! $required && ! $continueIfEmpty) {
-            return true;
-        }
-
-        if ($empty && $required && $allowEmpty && ! $continueIfEmpty) {
+        if ($empty && $allowEmpty && ! $continueIfEmpty) {
             return true;
         }
 
@@ -341,7 +336,7 @@ class Input implements
         // If we do not allow empty and the "continue if empty" flag are
         // BOTH false, we inject the "not empty" validator into the chain,
         // which adds that logic into the validation routine.
-        if (! $allowEmpty && ! $continueIfEmpty) {
+        if ($empty && ! $allowEmpty) {
             $this->injectNotEmptyValidator();
         }
 
@@ -394,11 +389,11 @@ class Input implements
         $this->notEmptyValidator = true;
 
         if (class_exists(AbstractPluginManager::class)) {
-            $chain->prependByName('NotEmpty', [], true);
+            $chain->prependByName('NotEmpty', [], !$this->continueIfEmpty());
 
             return;
         }
 
-        $chain->prependValidator(new NotEmpty(), true);
+        $chain->prependValidator(new NotEmpty(), !$this->continueIfEmpty());
     }
 }

--- a/src/Input.php
+++ b/src/Input.php
@@ -300,7 +300,9 @@ class Input implements
     public function merge(InputInterface $input)
     {
         $this->setBreakOnFailure($input->breakOnFailure());
-        $this->setContinueIfEmpty($input->continueIfEmpty());
+        if ($input instanceof Input) {
+            $this->setContinueIfEmpty($input->continueIfEmpty());
+        }
         $this->setErrorMessage($input->getErrorMessage());
         $this->setName($input->getName());
         $this->setRequired($input->isRequired());

--- a/src/Input.php
+++ b/src/Input.php
@@ -10,6 +10,7 @@
 namespace Zend\InputFilter;
 
 use Zend\Filter\FilterChain;
+use Zend\ServiceManager\AbstractPluginManager;
 use Zend\Validator\NotEmpty;
 use Zend\Validator\ValidatorChain;
 
@@ -390,7 +391,7 @@ class Input implements
 
         $this->notEmptyValidator = true;
 
-        if (class_exists('Zend\ServiceManager\AbstractPluginManager')) {
+        if (class_exists(AbstractPluginManager::class)) {
             $chain->prependByName('NotEmpty', [], true);
 
             return;

--- a/src/InputFilterAbstractServiceFactory.php
+++ b/src/InputFilterAbstractServiceFactory.php
@@ -50,7 +50,7 @@ class InputFilterAbstractServiceFactory implements AbstractFactoryInterface
      * @param ServiceLocatorInterface $inputFilters
      * @param string                  $cName
      * @param string                  $rName
-     * @return \Zend\InputFilter\InputFilterInterface
+     * @return InputFilterInterface
      */
     public function createServiceWithName(ServiceLocatorInterface $inputFilters, $cName, $rName)
     {

--- a/src/InputFilterInterface.php
+++ b/src/InputFilterInterface.php
@@ -145,7 +145,7 @@ interface InputFilterInterface extends Countable
      * Should return an associative array of named input/message list pairs.
      * Pairs should only be returned for inputs that failed validation.
      *
-     * @return array
+     * @return string[]
      */
     public function getMessages();
 }

--- a/src/InputFilterPluginManager.php
+++ b/src/InputFilterPluginManager.php
@@ -83,9 +83,10 @@ class InputFilterPluginManager extends AbstractPluginManager
         }
 
         throw new Exception\RuntimeException(sprintf(
-            'Plugin of type %s is invalid; must implement %s',
+            'Plugin of type %s is invalid; must implement %s or %s',
             (is_object($plugin) ? get_class($plugin) : gettype($plugin)),
-            InputFilterInterface::class
+            InputFilterInterface::class,
+            InputInterface::class
         ));
     }
 }

--- a/src/InputFilterPluginManager.php
+++ b/src/InputFilterPluginManager.php
@@ -24,7 +24,7 @@ class InputFilterPluginManager extends AbstractPluginManager
     /**
      * Default set of plugins
      *
-     * @var array
+     * @var string[]
      */
     protected $invokableClasses = [
         'inputfilter' => InputFilter::class,

--- a/src/InputFilterPluginManager.php
+++ b/src/InputFilterPluginManager.php
@@ -27,8 +27,8 @@ class InputFilterPluginManager extends AbstractPluginManager
      * @var array
      */
     protected $invokableClasses = [
-        'inputfilter' => 'Zend\InputFilter\InputFilter',
-        'collection'  => 'Zend\InputFilter\CollectionInputFilter',
+        'inputfilter' => InputFilter::class,
+        'collection'  => CollectionInputFilter::class,
     ];
 
     /**
@@ -83,8 +83,9 @@ class InputFilterPluginManager extends AbstractPluginManager
         }
 
         throw new Exception\RuntimeException(sprintf(
-            'Plugin of type %s is invalid; must implement Zend\InputFilter\InputFilterInterface',
-            (is_object($plugin) ? get_class($plugin) : gettype($plugin))
+            'Plugin of type %s is invalid; must implement %s',
+            (is_object($plugin) ? get_class($plugin) : gettype($plugin)),
+            InputFilterInterface::class
         ));
     }
 }

--- a/src/InputInterface.php
+++ b/src/InputInterface.php
@@ -119,7 +119,7 @@ interface InputInterface
     public function isValid();
 
     /**
-     * @return array
+     * @return string[]
      */
     public function getMessages();
 }

--- a/test/ArrayInputTest.php
+++ b/test/ArrayInputTest.php
@@ -111,32 +111,35 @@ class ArrayInputTest extends InputTest
         $input->setValue('bar');
     }
 
-    public function testValueMayBeInjected()
+    public function testSetValue($value = null)
     {
-        $input = $this->createDefaultInput();
-
-        $input->setValue(['bar']);
-        $this->assertEquals(['bar'], $input->getValue());
+        $this->markTestSkipped('ArrayInput::setValue is not compatible with InputInterface::setValue');
     }
 
-    public function testRetrievingValueFiltersTheValue()
+    /**
+     * Specific ArrayInput::setValue behavior
+     *
+     * @dataProvider setValueProvider
+     */
+    public function testArrayInputSetValue($value)
     {
+        $arrayValue = [$value];
+
+        $filterChain = $this->createFilterChainMock();
+        $filterChain->expects($this::atLeastOnce())
+            ->method('filter')
+            ->with($value)
+            ->willReturn('*filter*')
+        ;
+
         $input = $this->createDefaultInput();
+        $input->setFilterChain($filterChain);
 
-        $input->setValue(['bar']);
-        $filter = new Filter\StringToUpper();
-        $input->getFilterChain()->attach($filter);
-        $this->assertEquals(['BAR'], $input->getValue());
-    }
+        $return = $input->setValue($arrayValue);
+        $this->assertSame($input, $return, 'setValue() must return it self');
 
-    public function testCanRetrieveRawValue()
-    {
-        $input = $this->createDefaultInput();
-
-        $input->setValue(['bar']);
-        $filter = new Filter\StringToUpper();
-        $input->getFilterChain()->attach($filter);
-        $this->assertEquals(['bar'], $input->getRawValue());
+        $this->assertEquals($arrayValue, $input->getRawValue(), 'getRawValue() value not match');
+        $this->assertEquals(['*filter*'], $input->getValue(), 'getValue() value not match');
     }
 
     public function testIsValidReturnsFalseIfValidationChainFails()

--- a/test/ArrayInputTest.php
+++ b/test/ArrayInputTest.php
@@ -253,4 +253,11 @@ class ArrayInputTest extends InputTest
                     }));
         $this->assertTrue($this->input->isValid());
     }
+
+    protected function createDefaultInput()
+    {
+        $input = new ArrayInput();
+
+        return $input;
+    }
 }

--- a/test/ArrayInputTest.php
+++ b/test/ArrayInputTest.php
@@ -142,6 +142,40 @@ class ArrayInputTest extends InputTest
         $this->assertEquals(['*filter*'], $input->getValue(), 'getValue() value not match');
     }
 
+    public function testSetFallbackValue($fallbackValue = null)
+    {
+        $this->markTestSkipped('ArrayInput::setFallbackValue is not compatible with Input::setFallbackValue');
+    }
+
+    /**
+     * Specific ArrayInput::setFallbackValue behavior
+     *
+     * @dataProvider setValueProvider
+     */
+    public function testArrayInputSetFallbackValue($fallbackValue)
+    {
+        parent::testSetFallbackValue([$fallbackValue]);
+    }
+
+    public function testFallbackValueVsIsValidRules(
+        $fallbackValue = null,
+        $originalValue = null,
+        $isValid = null,
+        $expectedValue = null
+    ) {
+        $this->markTestSkipped('ArrayInput::setFallbackValue is not compatible with Input::setFallbackValue');
+    }
+
+    /**
+     * Specific ArrayInput::setFallbackValue and ArrayInput::setValue behavior
+     *
+     * @dataProvider fallbackValueVsIsValidProvider
+     */
+    public function testArrayInputFallbackValueVsIsValidRules($fallbackValue, $originalValue, $isValid, $expectedValue)
+    {
+        parent::testFallbackValueVsIsValidRules([$fallbackValue], [$originalValue], $isValid, [$expectedValue]);
+    }
+
     public function testIsValidReturnsFalseIfValidationChainFails()
     {
         $input = $this->createDefaultInput();
@@ -262,41 +296,6 @@ class ArrayInputTest extends InputTest
         $validators = $validatorChain->getValidators();
         $this->assertEquals(2, count($validators));
         $this->assertEquals($notEmptyMock, $validators[1]['instance']);
-    }
-
-    public function dataFallbackValue()
-    {
-        return [
-            [
-                'fallbackValue' => []
-            ],
-            [
-                'fallbackValue' => [''],
-            ],
-            [
-                'fallbackValue' => [null],
-            ],
-            [
-                'fallbackValue' => ['some value'],
-            ],
-        ];
-    }
-
-    /**
-     * @dataProvider dataFallbackValue
-     */
-    public function testFallbackValue($fallbackValue)
-    {
-        $input = $this->createDefaultInput();
-
-        $input->setFallbackValue($fallbackValue);
-        $validator = new Validator\Date();
-        $input->getValidatorChain()->attach($validator);
-        $input->setValue(['123']); // not a date
-
-        $this->assertTrue($input->isValid());
-        $this->assertEmpty($input->getMessages());
-        $this->assertSame($fallbackValue, $input->getValue());
     }
 
     public function testWhenRequiredAndAllowEmptyAndNotContinueIfEmptyValidatorsAreNotRun(Input $input = null, $value = null)

--- a/test/ArrayInputTest.php
+++ b/test/ArrayInputTest.php
@@ -11,6 +11,7 @@ namespace ZendTest\InputFilter;
 
 use Zend\Filter;
 use Zend\InputFilter\ArrayInput;
+use Zend\InputFilter\Exception\InvalidArgumentException;
 use Zend\Validator;
 
 /**
@@ -35,7 +36,7 @@ class ArrayInputTest extends InputTest
 
     public function testNotArrayValueCannotBeInjected()
     {
-        $this->setExpectedException('Zend\InputFilter\Exception\InvalidArgumentException');
+        $this->setExpectedException(InvalidArgumentException::class);
         $this->input->setValue('bar');
     }
 
@@ -131,7 +132,7 @@ class ArrayInputTest extends InputTest
         $this->assertTrue($this->input->isRequired());
         $this->input->setValue(['bar', '']);
 
-        $notEmptyMock = $this->getMock('Zend\Validator\NotEmpty', ['isValid']);
+        $notEmptyMock = $this->getMock(Validator\NotEmpty::class, ['isValid']);
         $notEmptyMock->expects($this->exactly(1))
             ->method('isValid')
             ->will($this->returnValue(false));
@@ -164,10 +165,10 @@ class ArrayInputTest extends InputTest
         $this->assertEquals(1, $filterChain->count());
 
         $validators = $validatorChain->getValidators();
-        $this->assertInstanceOf('Zend\Validator\Digits', $validators[0]['instance']);
+        $this->assertInstanceOf(Validator\Digits::class, $validators[0]['instance']);
 
         $filters = $filterChain->getFilters()->toArray();
-        $this->assertInstanceOf('Zend\Filter\StringTrim', $filters[0]);
+        $this->assertInstanceOf(Filter\StringTrim::class, $filters[0]);
     }
 
     public function testDoNotInjectNotEmptyValidatorIfAnywhereInChain()
@@ -175,7 +176,7 @@ class ArrayInputTest extends InputTest
         $this->assertTrue($this->input->isRequired());
         $this->input->setValue(['bar', '']);
 
-        $notEmptyMock = $this->getMock('Zend\Validator\NotEmpty', ['isValid']);
+        $notEmptyMock = $this->getMock(Validator\NotEmpty::class, ['isValid']);
         $notEmptyMock->expects($this->exactly(1))
             ->method('isValid')
             ->will($this->returnValue(false));

--- a/test/ArrayInputTest.php
+++ b/test/ArrayInputTest.php
@@ -13,6 +13,7 @@ use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use Zend\Filter;
 use Zend\InputFilter\ArrayInput;
 use Zend\InputFilter\Exception\InvalidArgumentException;
+use Zend\InputFilter\Input;
 use Zend\Validator;
 
 /**
@@ -20,6 +21,11 @@ use Zend\Validator;
  */
 class ArrayInputTest extends InputTest
 {
+    public function testNotEmptyValidatorNotInjectedIfContinueIfEmptyIsTrue()
+    {
+        $this->markTestIncomplete('Parent test does did not verify ArrayInput object. Pending review');
+    }
+
     public function testValueIsNullByDefault()
     {
         $this->markTestSkipped('Test is not enabled in ArrayInputTest');
@@ -169,7 +175,7 @@ class ArrayInputTest extends InputTest
 
     public function testMerge()
     {
-        $input = new ArrayInput('foo');
+        $input = $this->createDefaultInput();
         $input->setValue([' 123 ']);
         $filter = new Filter\StringTrim();
         $input->getFilterChain()->attach($filter);
@@ -248,6 +254,49 @@ class ArrayInputTest extends InputTest
         $this->assertTrue($input->isValid());
         $this->assertEmpty($input->getMessages());
         $this->assertSame($fallbackValue, $input->getValue());
+    }
+
+    public function testWhenRequiredAndAllowEmptyAndNotContinueIfEmptyValidatorsAreNotRun(Input $input = null, $value = null)
+    {
+        $this->markTestIncomplete('Parent test does did not verify ArrayInput object. Pending review');
+    }
+
+    public function testWhenRequiredAndAllowEmptyAndContinueIfEmptyValidatorsAreRun(Input $input = null, $value = null, $assertion = null)
+    {
+        $this->markTestIncomplete('Parent test does did not verify ArrayInput object. Pending review');
+    }
+
+    public function testWhenRequiredAndNotAllowEmptyAndNotContinueIfEmptyValidatorsAreNotRun(Input $input = null, $value = null)
+    {
+        $this->markTestIncomplete('Parent test does did not verify ArrayInput object. Pending review');
+    }
+
+    public function testWhenRequiredAndNotAllowEmptyAndContinueIfEmptyValidatorsAreRun(Input $input = null, $value = null, $assertion = null)
+    {
+        $this->markTestIncomplete('Parent test does did not verify ArrayInput object. Pending review');
+    }
+
+    public function testWhenNotRequiredAndAllowEmptyAndNotContinueIfEmptyValidatorsAreNotRun(Input $input = null, $value = null)
+    {
+        $this->markTestIncomplete('Parent test does did not verify ArrayInput object. Pending review');
+    }
+
+    public function testWhenNotRequiredAndNotAllowEmptyAndNotContinueIfEmptyValidatorsAreNotRun(Input $input = null, $value = null)
+    {
+        $this->markTestIncomplete('Parent test does did not verify ArrayInput object. Pending review');
+    }
+
+    public function testWhenNotRequiredAndAllowEmptyAndContinueIfEmptyValidatorsAreRun(Input $input = null, $value = null, $assertion = null)
+    {
+        $this->markTestIncomplete('Parent test does did not verify ArrayInput object. Pending review');
+    }
+
+    public function testWhenNotRequiredAndNotAllowEmptyAndContinueIfEmptyValidatorsAreRun(
+        Input $input = null,
+        $value = null,
+        $assertion = null
+    ) {
+        $this->markTestIncomplete('Parent test does did not verify ArrayInput object. Pending review');
     }
 
     public function emptyValuesProvider()

--- a/test/ArrayInputTest.php
+++ b/test/ArrayInputTest.php
@@ -176,6 +176,43 @@ class ArrayInputTest extends InputTest
         parent::testFallbackValueVsIsValidRules([$fallbackValue], [$originalValue], $isValid, [$expectedValue]);
     }
 
+    public function testInputContinueIfEmptyAllowEmptyVsIsRequiredVsIsValidRules(
+        $continueIfEmpty = null,
+        $allowEmpty = null,
+        $isRequired = null,
+        $isValid = null,
+        $value = null,
+        $expectedIsValid = null,
+        $expectedMessages = null
+    ) {
+        $this->markTestSkipped('ArrayInput::setValue is not compatible with InputInterface::setValue');
+    }
+
+    /**
+     * Specific ArrayInput::setValue behavior
+     *
+     * @dataProvider continueIfEmptyVsAllowEmptyVsIsRequiredVsIsValidProviderRules
+     */
+    public function testArrayInputContinueIfEmptyAllowEmptyVsIsRequiredVsIsValidRules(
+        $continueIfEmpty,
+        $allowEmpty,
+        $isRequired,
+        $isValid,
+        $value,
+        $expectedIsValid,
+        $expectedMessages
+    ) {
+        parent::testInputContinueIfEmptyAllowEmptyVsIsRequiredVsIsValidRules(
+            $continueIfEmpty,
+            $allowEmpty,
+            $isRequired,
+            $isValid,
+            [$value],
+            $expectedIsValid,
+            $expectedMessages
+        );
+    }
+
     public function testIsValidReturnsFalseIfValidationChainFails()
     {
         $input = $this->createDefaultInput();

--- a/test/ArrayInputTest.php
+++ b/test/ArrayInputTest.php
@@ -43,11 +43,14 @@ class ArrayInputTest extends InputTest
         $this->assertCount(0, $input->getValue());
     }
 
-    public function testNotArrayValueCannotBeInjected()
+    public function testSetValueWithInvalidInputTypeThrowsInvalidArgumentException()
     {
         $input = $this->createDefaultInput();
 
-        $this->setExpectedException(InvalidArgumentException::class);
+        $this->setExpectedException(
+            InvalidArgumentException::class,
+            'Value must be an array, string given'
+        );
         $input->setValue('bar');
     }
 

--- a/test/ArrayInputTest.php
+++ b/test/ArrayInputTest.php
@@ -21,6 +21,11 @@ use Zend\Validator;
  */
 class ArrayInputTest extends InputTest
 {
+    public function testIsASubclassOfInput()
+    {
+        $this->assertInstanceOf(Input::class, $this->createDefaultInput());
+    }
+
     public function testNotEmptyValidatorNotInjectedIfContinueIfEmptyIsTrue()
     {
         $this->markTestIncomplete('Parent test does did not verify ArrayInput object. Pending review');

--- a/test/ArrayInputTest.php
+++ b/test/ArrayInputTest.php
@@ -13,6 +13,9 @@ use Zend\InputFilter\ArrayInput;
 use Zend\Filter;
 use Zend\Validator;
 
+/**
+ * @covers Zend\InputFilter\ArrayInput
+ */
 class ArrayInputTest extends InputTest
 {
     public function setUp()

--- a/test/ArrayInputTest.php
+++ b/test/ArrayInputTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\InputFilter;
 
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use Zend\Filter;
 use Zend\InputFilter\ArrayInput;
 use Zend\InputFilter\Exception\InvalidArgumentException;
@@ -132,6 +133,7 @@ class ArrayInputTest extends InputTest
         $this->assertTrue($this->input->isRequired());
         $this->input->setValue(['bar', '']);
 
+        /** @var Validator\NotEmpty|MockObject $notEmptyMock */
         $notEmptyMock = $this->getMock(Validator\NotEmpty::class, ['isValid']);
         $notEmptyMock->expects($this->exactly(1))
             ->method('isValid')
@@ -176,6 +178,7 @@ class ArrayInputTest extends InputTest
         $this->assertTrue($this->input->isRequired());
         $this->input->setValue(['bar', '']);
 
+        /** @var Validator\NotEmpty|MockObject $notEmptyMock */
         $notEmptyMock = $this->getMock(Validator\NotEmpty::class, ['isValid']);
         $notEmptyMock->expects($this->exactly(1))
             ->method('isValid')

--- a/test/ArrayInputTest.php
+++ b/test/ArrayInputTest.php
@@ -20,11 +20,6 @@ use Zend\Validator;
  */
 class ArrayInputTest extends InputTest
 {
-    public function setUp()
-    {
-        $this->input = new ArrayInput('foo');
-    }
-
     public function testValueIsNullByDefault()
     {
         $this->markTestSkipped('Test is not enabled in ArrayInputTest');
@@ -32,106 +27,130 @@ class ArrayInputTest extends InputTest
 
     public function testValueIsEmptyArrayByDefault()
     {
-        $this->assertCount(0, $this->input->getValue());
+        $input = $this->createDefaultInput();
+
+        $this->assertCount(0, $input->getValue());
     }
 
     public function testNotArrayValueCannotBeInjected()
     {
+        $input = $this->createDefaultInput();
+
         $this->setExpectedException(InvalidArgumentException::class);
-        $this->input->setValue('bar');
+        $input->setValue('bar');
     }
 
     public function testValueMayBeInjected()
     {
-        $this->input->setValue(['bar']);
-        $this->assertEquals(['bar'], $this->input->getValue());
+        $input = $this->createDefaultInput();
+
+        $input->setValue(['bar']);
+        $this->assertEquals(['bar'], $input->getValue());
     }
 
     public function testRetrievingValueFiltersTheValue()
     {
-        $this->input->setValue(['bar']);
+        $input = $this->createDefaultInput();
+
+        $input->setValue(['bar']);
         $filter = new Filter\StringToUpper();
-        $this->input->getFilterChain()->attach($filter);
-        $this->assertEquals(['BAR'], $this->input->getValue());
+        $input->getFilterChain()->attach($filter);
+        $this->assertEquals(['BAR'], $input->getValue());
     }
 
     public function testCanRetrieveRawValue()
     {
-        $this->input->setValue(['bar']);
+        $input = $this->createDefaultInput();
+
+        $input->setValue(['bar']);
         $filter = new Filter\StringToUpper();
-        $this->input->getFilterChain()->attach($filter);
-        $this->assertEquals(['bar'], $this->input->getRawValue());
+        $input->getFilterChain()->attach($filter);
+        $this->assertEquals(['bar'], $input->getRawValue());
     }
 
     public function testIsValidReturnsFalseIfValidationChainFails()
     {
-        $this->input->setValue(['123', 'bar']);
+        $input = $this->createDefaultInput();
+
+        $input->setValue(['123', 'bar']);
         $validator = new Validator\Digits();
-        $this->input->getValidatorChain()->attach($validator);
-        $this->assertFalse($this->input->isValid());
+        $input->getValidatorChain()->attach($validator);
+        $this->assertFalse($input->isValid());
     }
 
     public function testIsValidReturnsTrueIfValidationChainSucceeds()
     {
-        $this->input->setValue(['123', '123']);
+        $input = $this->createDefaultInput();
+
+        $input->setValue(['123', '123']);
         $validator = new Validator\Digits();
-        $this->input->getValidatorChain()->attach($validator);
-        $this->assertTrue($this->input->isValid());
+        $input->getValidatorChain()->attach($validator);
+        $this->assertTrue($input->isValid());
     }
 
     public function testValidationOperatesOnFilteredValue()
     {
-        $this->input->setValue([' 123 ', '  123']);
+        $input = $this->createDefaultInput();
+
+        $input->setValue([' 123 ', '  123']);
         $filter = new Filter\StringTrim();
-        $this->input->getFilterChain()->attach($filter);
+        $input->getFilterChain()->attach($filter);
         $validator = new Validator\Digits();
-        $this->input->getValidatorChain()->attach($validator);
-        $this->assertTrue($this->input->isValid());
+        $input->getValidatorChain()->attach($validator);
+        $this->assertTrue($input->isValid());
     }
 
     public function testGetMessagesReturnsValidationMessages()
     {
-        $this->input->setValue(['bar']);
+        $input = $this->createDefaultInput();
+
+        $input->setValue(['bar']);
         $validator = new Validator\Digits();
-        $this->input->getValidatorChain()->attach($validator);
-        $this->assertFalse($this->input->isValid());
-        $messages = $this->input->getMessages();
+        $input->getValidatorChain()->attach($validator);
+        $this->assertFalse($input->isValid());
+        $messages = $input->getMessages();
         $this->assertArrayHasKey(Validator\Digits::NOT_DIGITS, $messages);
     }
 
     public function testSpecifyingMessagesToInputReturnsThoseOnFailedValidation()
     {
-        $this->input->setValue(['bar']);
+        $input = $this->createDefaultInput();
+
+        $input->setValue(['bar']);
         $validator = new Validator\Digits();
-        $this->input->getValidatorChain()->attach($validator);
-        $this->input->setErrorMessage('Please enter only digits');
-        $this->assertFalse($this->input->isValid());
-        $messages = $this->input->getMessages();
+        $input->getValidatorChain()->attach($validator);
+        $input->setErrorMessage('Please enter only digits');
+        $this->assertFalse($input->isValid());
+        $messages = $input->getMessages();
         $this->assertArrayNotHasKey(Validator\Digits::NOT_DIGITS, $messages);
         $this->assertContains('Please enter only digits', $messages);
     }
 
     public function testNotEmptyValidatorAddedWhenIsValidIsCalled()
     {
-        $this->assertTrue($this->input->isRequired());
-        $this->input->setValue(['bar', '']);
-        $validatorChain = $this->input->getValidatorChain();
+        $input = $this->createDefaultInput();
+
+        $this->assertTrue($input->isRequired());
+        $input->setValue(['bar', '']);
+        $validatorChain = $input->getValidatorChain();
         $this->assertEquals(0, count($validatorChain->getValidators()));
 
-        $this->assertFalse($this->input->isValid());
-        $messages = $this->input->getMessages();
+        $this->assertFalse($input->isValid());
+        $messages = $input->getMessages();
         $this->assertArrayHasKey('isEmpty', $messages);
         $this->assertEquals(1, count($validatorChain->getValidators()));
 
         // Assert that NotEmpty validator wasn't added again
-        $this->assertFalse($this->input->isValid());
+        $this->assertFalse($input->isValid());
         $this->assertEquals(1, count($validatorChain->getValidators()));
     }
 
     public function testRequiredNotEmptyValidatorNotAddedWhenOneExists()
     {
-        $this->assertTrue($this->input->isRequired());
-        $this->input->setValue(['bar', '']);
+        $input = $this->createDefaultInput();
+
+        $this->assertTrue($input->isRequired());
+        $input->setValue(['bar', '']);
 
         /** @var Validator\NotEmpty|MockObject $notEmptyMock */
         $notEmptyMock = $this->getMock(Validator\NotEmpty::class, ['isValid']);
@@ -139,9 +158,9 @@ class ArrayInputTest extends InputTest
             ->method('isValid')
             ->will($this->returnValue(false));
 
-        $validatorChain = $this->input->getValidatorChain();
+        $validatorChain = $input->getValidatorChain();
         $validatorChain->prependValidator($notEmptyMock);
-        $this->assertFalse($this->input->isValid());
+        $this->assertFalse($input->isValid());
 
         $validators = $validatorChain->getValidators();
         $this->assertEquals(1, count($validators));
@@ -175,8 +194,10 @@ class ArrayInputTest extends InputTest
 
     public function testDoNotInjectNotEmptyValidatorIfAnywhereInChain()
     {
-        $this->assertTrue($this->input->isRequired());
-        $this->input->setValue(['bar', '']);
+        $input = $this->createDefaultInput();
+
+        $this->assertTrue($input->isRequired());
+        $input->setValue(['bar', '']);
 
         /** @var Validator\NotEmpty|MockObject $notEmptyMock */
         $notEmptyMock = $this->getMock(Validator\NotEmpty::class, ['isValid']);
@@ -184,10 +205,10 @@ class ArrayInputTest extends InputTest
             ->method('isValid')
             ->will($this->returnValue(false));
 
-        $validatorChain = $this->input->getValidatorChain();
+        $validatorChain = $input->getValidatorChain();
         $validatorChain->attach(new Validator\Digits());
         $validatorChain->attach($notEmptyMock);
-        $this->assertFalse($this->input->isValid());
+        $this->assertFalse($input->isValid());
 
         $validators = $validatorChain->getValidators();
         $this->assertEquals(2, count($validators));
@@ -217,14 +238,16 @@ class ArrayInputTest extends InputTest
      */
     public function testFallbackValue($fallbackValue)
     {
-        $this->input->setFallbackValue($fallbackValue);
-        $validator = new Validator\Date();
-        $this->input->getValidatorChain()->attach($validator);
-        $this->input->setValue(['123']); // not a date
+        $input = $this->createDefaultInput();
 
-        $this->assertTrue($this->input->isValid());
-        $this->assertEmpty($this->input->getMessages());
-        $this->assertSame($fallbackValue, $this->input->getValue());
+        $input->setFallbackValue($fallbackValue);
+        $validator = new Validator\Date();
+        $input->getValidatorChain()->attach($validator);
+        $input->setValue(['123']); // not a date
+
+        $this->assertTrue($input->isValid());
+        $this->assertEmpty($input->getMessages());
+        $this->assertSame($fallbackValue, $input->getValue());
     }
 
     public function emptyValuesProvider()
@@ -238,25 +261,29 @@ class ArrayInputTest extends InputTest
 
     public function testNotAllowEmptyWithFilterConvertsNonemptyToEmptyIsNotValid()
     {
-        $this->input->setValue(['nonempty'])
+        $input = $this->createDefaultInput();
+
+        $input->setValue(['nonempty'])
                     ->getFilterChain()->attach(new Filter\Callback(function () {
                         return '';
                     }));
-        $this->assertFalse($this->input->isValid());
+        $this->assertFalse($input->isValid());
     }
 
     public function testNotAllowEmptyWithFilterConvertsEmptyToNonEmptyIsValid()
     {
-        $this->input->setValue([''])
+        $input = $this->createDefaultInput();
+
+        $input->setValue([''])
                     ->getFilterChain()->attach(new Filter\Callback(function () {
                         return 'nonempty';
                     }));
-        $this->assertTrue($this->input->isValid());
+        $this->assertTrue($input->isValid());
     }
 
     protected function createDefaultInput()
     {
-        $input = new ArrayInput();
+        $input = new ArrayInput('foo');
 
         return $input;
     }

--- a/test/ArrayInputTest.php
+++ b/test/ArrayInputTest.php
@@ -9,8 +9,8 @@
 
 namespace ZendTest\InputFilter;
 
-use Zend\InputFilter\ArrayInput;
 use Zend\Filter;
+use Zend\InputFilter\ArrayInput;
 use Zend\Validator;
 
 /**

--- a/test/BaseInputFilterTest.php
+++ b/test/BaseInputFilterTest.php
@@ -170,47 +170,6 @@ class BaseInputFilterTest extends TestCase
         $filter->setValidationGroup('notExistInputFilter');
     }
 
-    public function testAddingInputsIncreasesCountOfFilter()
-    {
-        $filter = $this->createDefaultInputFilter();
-        $foo    = new Input('foo');
-        $filter->add($foo);
-        $this->assertEquals(1, count($filter));
-        $bar    = new Input('bar');
-        $filter->add($bar);
-        $this->assertEquals(2, count($filter));
-    }
-
-    public function testAddingInputWithNameDoesNotInjectNameInInput()
-    {
-        $filter = $this->createDefaultInputFilter();
-        $foo    = new Input('foo');
-        $filter->add($foo, 'bar');
-        $test   = $filter->get('bar');
-        $this->assertSame($foo, $test);
-        $this->assertEquals('foo', $foo->getName());
-    }
-
-    public function testCanAddInputFilterAsInput()
-    {
-        $parent = $this->createDefaultInputFilter();
-        $child  = $this->createDefaultInputFilter();
-        $parent->add($child, 'child');
-        $this->assertEquals(1, count($parent));
-        $this->assertSame($child, $parent->get('child'));
-    }
-
-    public function testCanRemoveInputFilter()
-    {
-        $parent = $this->createDefaultInputFilter();
-        $child  = $this->createDefaultInputFilter();
-        $parent->add($child, 'child');
-        $this->assertEquals(1, count($parent));
-        $this->assertSame($child, $parent->get('child'));
-        $parent->remove('child');
-        $this->assertEquals(0, count($parent));
-    }
-
     public function getInputFilter()
     {
         $filter = $this->createDefaultInputFilter();

--- a/test/BaseInputFilterTest.php
+++ b/test/BaseInputFilterTest.php
@@ -13,11 +13,11 @@ use ArrayObject;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use PHPUnit_Framework_TestCase as TestCase;
 use stdClass;
+use Zend\Filter;
+use Zend\InputFilter\BaseInputFilter as InputFilter;
+use Zend\InputFilter\FileInput;
 use Zend\InputFilter\Input;
 use Zend\InputFilter\InputInterface;
-use Zend\InputFilter\FileInput;
-use Zend\InputFilter\BaseInputFilter as InputFilter;
-use Zend\Filter;
 use Zend\Validator;
 
 /**

--- a/test/BaseInputFilterTest.php
+++ b/test/BaseInputFilterTest.php
@@ -14,9 +14,12 @@ use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use PHPUnit_Framework_TestCase as TestCase;
 use stdClass;
 use Zend\Filter;
+use Zend\InputFilter\ArrayInput;
 use Zend\InputFilter\BaseInputFilter as InputFilter;
+use Zend\InputFilter\Exception\InvalidArgumentException;
 use Zend\InputFilter\FileInput;
 use Zend\InputFilter\Input;
+use Zend\InputFilter\InputFilterInterface;
 use Zend\InputFilter\InputInterface;
 use Zend\Validator;
 
@@ -258,7 +261,7 @@ class BaseInputFilterTest extends TestCase
         // we expect setValidationGroup to throw an exception when flat is treated
         // like an inputfilter which it actually isn't
         $this->setExpectedException(
-            'Zend\InputFilter\Exception\InvalidArgumentException',
+            InvalidArgumentException::class,
             'Input "flat" must implement InputFilterInterface'
         );
         $filter->setValidationGroup(['flat' => 'foo']);
@@ -284,12 +287,12 @@ class BaseInputFilterTest extends TestCase
         $invalidInputs = $filter->getInvalidInput();
         $this->assertArrayNotHasKey('foo', $invalidInputs);
         $this->assertArrayHasKey('bar', $invalidInputs);
-        $this->assertInstanceOf('Zend\InputFilter\Input', $invalidInputs['bar']);
+        $this->assertInstanceOf(Input::class, $invalidInputs['bar']);
         $this->assertArrayHasKey('nest', $invalidInputs/*, var_export($invalidInputs, 1)*/);
-        $this->assertInstanceOf('Zend\InputFilter\InputFilterInterface', $invalidInputs['nest']);
+        $this->assertInstanceOf(InputFilterInterface::class, $invalidInputs['nest']);
         $nestInvalids = $invalidInputs['nest']->getInvalidInput();
         $this->assertArrayHasKey('foo', $nestInvalids);
-        $this->assertInstanceOf('Zend\InputFilter\Input', $nestInvalids['foo']);
+        $this->assertInstanceOf(Input::class, $nestInvalids['foo']);
         $this->assertArrayNotHasKey('bar', $nestInvalids);
     }
 
@@ -312,15 +315,15 @@ class BaseInputFilterTest extends TestCase
         $this->assertFalse($filter->isValid());
         $validInputs = $filter->getValidInput();
         $this->assertArrayHasKey('foo', $validInputs);
-        $this->assertInstanceOf('Zend\InputFilter\Input', $validInputs['foo']);
+        $this->assertInstanceOf(Input::class, $validInputs['foo']);
         $this->assertArrayNotHasKey('bar', $validInputs);
         $this->assertArrayHasKey('nest', $validInputs);
-        $this->assertInstanceOf('Zend\InputFilter\InputFilterInterface', $validInputs['nest']);
+        $this->assertInstanceOf(InputFilterInterface::class, $validInputs['nest']);
         $nestValids = $validInputs['nest']->getValidInput();
         $this->assertArrayHasKey('foo', $nestValids);
-        $this->assertInstanceOf('Zend\InputFilter\Input', $nestValids['foo']);
+        $this->assertInstanceOf(Input::class, $nestValids['foo']);
         $this->assertArrayHasKey('bar', $nestValids);
-        $this->assertInstanceOf('Zend\InputFilter\Input', $nestValids['bar']);
+        $this->assertInstanceOf(Input::class, $nestValids['bar']);
     }
 
     public function testValuesRetrievedAreFiltered()
@@ -812,7 +815,7 @@ class BaseInputFilterTest extends TestCase
                 [
                     'validator' => new \Zend\Validator\IsInstanceOf(
                         [
-                            'className' => 'Zend\InputFilter\Input'
+                            'className' => Input::class
                         ]
                     )
                 ]
@@ -905,7 +908,7 @@ class BaseInputFilterTest extends TestCase
      */
     public function testPopulateSupportsArrayInputEvenIfDataMissing()
     {
-        $arrayInput = $this->getMock('Zend\InputFilter\ArrayInput');
+        $arrayInput = $this->getMock(ArrayInput::class);
         $arrayInput
             ->expects($this->once())
             ->method('setValue')

--- a/test/BaseInputFilterTest.php
+++ b/test/BaseInputFilterTest.php
@@ -908,6 +908,7 @@ class BaseInputFilterTest extends TestCase
      */
     public function testPopulateSupportsArrayInputEvenIfDataMissing()
     {
+        /** @var ArrayInput|MockObject $arrayInput */
         $arrayInput = $this->getMock(ArrayInput::class);
         $arrayInput
             ->expects($this->once())

--- a/test/BaseInputFilterTest.php
+++ b/test/BaseInputFilterTest.php
@@ -28,6 +28,10 @@ use Zend\Validator;
  */
 class BaseInputFilterTest extends TestCase
 {
+    use InputFilterInterfaceTestTrait;
+    use ReplaceableInputInterfaceTestTrait;
+    use UnknownInputsCapableInterfaceTestTrait;
+
     public function testInputFilterIsEmptyByDefault()
     {
         $filter = new InputFilter();
@@ -1137,5 +1141,22 @@ class BaseInputFilterTest extends TestCase
         $data = new ArrayObject(['foo' => ' valid ']);
         $filter->setData($data);
         $this->assertTrue($filter->isValid());
+    }
+
+    protected function createDefaultInputFilter()
+    {
+        $inputFilter = new InputFilter();
+
+        return $inputFilter;
+    }
+
+    protected function createDefaultReplaceableInput()
+    {
+        return $this->createDefaultInputFilter();
+    }
+
+    protected function createDefaultUnknownInputsCapable()
+    {
+        return $this->createDefaultInputFilter();
     }
 }

--- a/test/BaseInputFilterTest.php
+++ b/test/BaseInputFilterTest.php
@@ -170,6 +170,30 @@ class BaseInputFilterTest extends TestCase
         $filter->setValidationGroup('notExistInputFilter');
     }
 
+    /**
+     * @dataProvider inputProvider
+     *
+     * @param mixed $input
+     * @param string $inputName Name used to retrieve this input.
+     * @param mixed $expectedInput
+     */
+    public function testReplace($input, $inputName, $expectedInput)
+    {
+        $inputFilter = new InputFilter();
+        $nameToReplace = 'replace_me';
+        $inputToReplace = new Input($nameToReplace);
+
+        $inputFilter->add($inputToReplace);
+        $currentNumberOfFilters = count($inputFilter);
+
+        $return = $inputFilter->replace($input, $nameToReplace);
+        $this->assertSame($inputFilter, $return, 'BaseInputFilter::replace() must return it self');
+        $this->assertCount($currentNumberOfFilters, $inputFilter, "Number of filters shouldn't change");
+
+        $returnInput = $inputFilter->get($nameToReplace);
+        $this->assertEquals($expectedInput, $returnInput, 'InputFilter::get() does not match the expected input');
+    }
+
     public function getInputFilter()
     {
         $filter = $this->createDefaultInputFilter();

--- a/test/BaseInputFilterTest.php
+++ b/test/BaseInputFilterTest.php
@@ -34,13 +34,13 @@ class BaseInputFilterTest extends TestCase
 
     public function testInputFilterIsEmptyByDefault()
     {
-        $filter = new InputFilter();
+        $filter = $this->createDefaultInputFilter();
         $this->assertEquals(0, count($filter));
     }
 
     public function testAddingInputsIncreasesCountOfFilter()
     {
-        $filter = new InputFilter();
+        $filter = $this->createDefaultInputFilter();
         $foo    = new Input('foo');
         $filter->add($foo);
         $this->assertEquals(1, count($filter));
@@ -51,7 +51,7 @@ class BaseInputFilterTest extends TestCase
 
     public function testAddingInputWithNameDoesNotInjectNameInInput()
     {
-        $filter = new InputFilter();
+        $filter = $this->createDefaultInputFilter();
         $foo    = new Input('foo');
         $filter->add($foo, 'bar');
         $test   = $filter->get('bar');
@@ -61,8 +61,8 @@ class BaseInputFilterTest extends TestCase
 
     public function testCanAddInputFilterAsInput()
     {
-        $parent = new InputFilter();
-        $child  = new InputFilter();
+        $parent = $this->createDefaultInputFilter();
+        $child  = $this->createDefaultInputFilter();
         $parent->add($child, 'child');
         $this->assertEquals(1, count($parent));
         $this->assertSame($child, $parent->get('child'));
@@ -70,8 +70,8 @@ class BaseInputFilterTest extends TestCase
 
     public function testCanRemoveInputFilter()
     {
-        $parent = new InputFilter();
-        $child  = new InputFilter();
+        $parent = $this->createDefaultInputFilter();
+        $child  = $this->createDefaultInputFilter();
         $parent->add($child, 'child');
         $this->assertEquals(1, count($parent));
         $this->assertSame($child, $parent->get('child'));
@@ -81,7 +81,7 @@ class BaseInputFilterTest extends TestCase
 
     public function getInputFilter()
     {
-        $filter = new InputFilter();
+        $filter = $this->createDefaultInputFilter();
 
         $foo = new Input();
         $foo->getFilterChain()->attachByName('stringtrim')
@@ -113,7 +113,7 @@ class BaseInputFilterTest extends TestCase
 
     public function getChildInputFilter()
     {
-        $filter = new InputFilter();
+        $filter = $this->createDefaultInputFilter();
 
         $foo = new Input();
         $foo->getFilterChain()->attachByName('stringtrim')
@@ -245,9 +245,9 @@ class BaseInputFilterTest extends TestCase
                 'deep-input2' => 'deep-foo2',
             ]
         ];
-        $filter = new InputFilter;
+        $filter = $this->createDefaultInputFilter();
         $filter->add(new Input, 'flat');
-        $deepInputFilter = new InputFilter;
+        $deepInputFilter = $this->createDefaultInputFilter();
         $deepInputFilter->add(new Input, 'deep-input1');
         $deepInputFilter->add(new Input, 'deep-input2');
         $filter->add($deepInputFilter, 'deep');
@@ -461,7 +461,7 @@ class BaseInputFilterTest extends TestCase
      */
     public function testValidationCanUseContext()
     {
-        $filter = new InputFilter();
+        $filter = $this->createDefaultInputFilter();
 
         $store = new stdClass;
         $foo   = new Input();
@@ -491,7 +491,7 @@ class BaseInputFilterTest extends TestCase
      */
     public function testInputBreakOnFailureFlagIsHonoredWhenValidating()
     {
-        $filter = new InputFilter();
+        $filter = $this->createDefaultInputFilter();
 
         $store = new stdClass;
         $foo   = new Input();
@@ -518,7 +518,7 @@ class BaseInputFilterTest extends TestCase
 
     public function testValidationSkipsFieldsMarkedNotRequiredWhenNoDataPresent()
     {
-        $filter = new InputFilter();
+        $filter = $this->createDefaultInputFilter();
 
         $optionalInputName = 'fooOptionalInput';
         /** @var InputInterface|MockObject $optionalInput */
@@ -550,7 +550,7 @@ class BaseInputFilterTest extends TestCase
 
     public function testValidationSkipsFileInputsMarkedNotRequiredWhenNoFileDataIsPresent()
     {
-        $filter = new InputFilter();
+        $filter = $this->createDefaultInputFilter();
 
         $foo   = new FileInput();
         $foo->getValidatorChain()->attach(new Validator\File\UploadFile());
@@ -578,7 +578,7 @@ class BaseInputFilterTest extends TestCase
 
     public function testValidationSkipsFileInputsMarkedNotRequiredWhenNoMultiFileDataIsPresent()
     {
-        $filter = new InputFilter();
+        $filter = $this->createDefaultInputFilter();
         $foo    = new FileInput();
         $foo->setRequired(false);
         $filter->add($foo, 'foo');
@@ -603,7 +603,7 @@ class BaseInputFilterTest extends TestCase
 
     public function testValidationAllowsEmptyValuesToRequiredInputWhenAllowEmptyFlagIsTrue()
     {
-        $filter = new InputFilter();
+        $filter = $this->createDefaultInputFilter();
 
         $foo   = new Input('foo');
         $foo->getValidatorChain()->attach(new Validator\StringLength(3, 5));
@@ -630,7 +630,7 @@ class BaseInputFilterTest extends TestCase
 
     public function testValidationMarksInputInvalidWhenRequiredAndAllowEmptyFlagIsFalse()
     {
-        $filter = new InputFilter();
+        $filter = $this->createDefaultInputFilter();
 
         $foo   = new Input();
         $foo->getValidatorChain()->attach(new Validator\StringLength(3, 5));
@@ -669,7 +669,7 @@ class BaseInputFilterTest extends TestCase
     public function testValidationMarksInputValidWhenAllowEmptyFlagIsTrueAndContinueIfEmptyIsTrueAndContextValidatesEmptyField($allowEmpty, $blankIsValid, $valid)
     {
         // @codingStandardsIgnoreEnd
-        $filter = new InputFilter();
+        $filter = $this->createDefaultInputFilter();
 
         $data = [
             'allowEmpty' => $allowEmpty,
@@ -734,7 +734,7 @@ class BaseInputFilterTest extends TestCase
 
     public function testGetRequiredNotEmptyValidationMessages()
     {
-        $filter = new InputFilter();
+        $filter = $this->createDefaultInputFilter();
 
         $foo   = new Input();
         $foo->setRequired(true);
@@ -809,7 +809,7 @@ class BaseInputFilterTest extends TestCase
 
     public function testValidateUseExplodeAndInstanceOf()
     {
-        $filter = new InputFilter();
+        $filter = $this->createDefaultInputFilter();
 
         $input = new Input();
         $input->setRequired(true);
@@ -840,7 +840,7 @@ class BaseInputFilterTest extends TestCase
 
     public function testGetInputs()
     {
-        $filter = new InputFilter();
+        $filter = $this->createDefaultInputFilter();
 
         $foo = new Input('foo');
         $bar = new Input('bar');
@@ -860,7 +860,7 @@ class BaseInputFilterTest extends TestCase
      */
     public function testAddingExistingInputWillMergeIntoExisting()
     {
-        $filter = new InputFilter();
+        $filter = $this->createDefaultInputFilter();
 
         $foo1    = new Input('foo');
         $foo1->setRequired(true);
@@ -879,7 +879,7 @@ class BaseInputFilterTest extends TestCase
      */
     public function testIsValidWhenValuesSetOnFilters()
     {
-        $filter = new InputFilter();
+        $filter = $this->createDefaultInputFilter();
 
         $foo = new Input();
         $foo->getFilterChain()->attachByName('stringtrim')
@@ -919,7 +919,7 @@ class BaseInputFilterTest extends TestCase
             ->method('setValue')
             ->with([]);
 
-        $filter = new InputFilter();
+        $filter = $this->createDefaultInputFilter();
         $filter->add($arrayInput, 'arrayInput');
         $filter->setData(['foo' => 'bar']);
     }
@@ -929,8 +929,8 @@ class BaseInputFilterTest extends TestCase
      */
     public function testMerge()
     {
-        $inputFilter       = new InputFilter();
-        $originInputFilter = new InputFilter();
+        $inputFilter       = $this->createDefaultInputFilter();
+        $originInputFilter = $this->createDefaultInputFilter();
 
         $inputFilter->add(new Input(), 'foo');
         $inputFilter->add(new Input(), 'bar');
@@ -963,7 +963,7 @@ class BaseInputFilterTest extends TestCase
             return false;
         }));
 
-        $filter = new InputFilter();
+        $filter = $this->createDefaultInputFilter();
         $filter->add($input)
                ->setData(['foo' => 'nonempty']);
 
@@ -985,7 +985,7 @@ class BaseInputFilterTest extends TestCase
             return false;
         }));
 
-        $filter = new InputFilter();
+        $filter = $this->createDefaultInputFilter();
         $filter->add($input)
                ->setData(['foo' => 'nonempty']);
 
@@ -1005,7 +1005,7 @@ class BaseInputFilterTest extends TestCase
         $bar->setRequired(true);
         $bar->setAllowEmpty(true);
 
-        $filter = new InputFilter();
+        $filter = $this->createDefaultInputFilter();
         $filter->add($foo);
         $filter->add($bar);
 
@@ -1035,7 +1035,7 @@ class BaseInputFilterTest extends TestCase
         $bar->setRequired(true);
         $bar->setAllowEmpty(true);
 
-        $filter = new InputFilter();
+        $filter = $this->createDefaultInputFilter();
         $filter->add($foo);
         $filter->add($bar);
 
@@ -1059,7 +1059,7 @@ class BaseInputFilterTest extends TestCase
         $bar->setRequired(true);
         $bar->setFallbackValue('baz');
 
-        $filter = new InputFilter();
+        $filter = $this->createDefaultInputFilter();
         $filter->add($foo);
         $filter->add($bar);
 
@@ -1084,7 +1084,7 @@ class BaseInputFilterTest extends TestCase
         $bar->setAllowEmpty(true);
         $bar->setFallbackValue('baz');
 
-        $filter = new InputFilter();
+        $filter = $this->createDefaultInputFilter();
         $filter->add($foo);
         $filter->add($bar);
 
@@ -1110,7 +1110,7 @@ class BaseInputFilterTest extends TestCase
         $bar->setRequired(true);
         $bar->setFallbackValue('baz');
 
-        $filter = new InputFilter();
+        $filter = $this->createDefaultInputFilter();
         $filter->add($foo);
         $filter->add($bar);
 
@@ -1131,7 +1131,7 @@ class BaseInputFilterTest extends TestCase
      */
     public function testAllowsValidatingArrayAccessData()
     {
-        $filter = new InputFilter();
+        $filter = $this->createDefaultInputFilter();
         $foo = new Input();
         $foo->getFilterChain()->attachByName('stringtrim')
                               ->attachByName('alpha');

--- a/test/BaseInputFilterTest.php
+++ b/test/BaseInputFilterTest.php
@@ -811,9 +811,9 @@ class BaseInputFilterTest extends TestCase
         $input->setRequired(true);
 
         $input->getValidatorChain()->attach(
-            new \Zend\Validator\Explode(
+            new Validator\Explode(
                 [
-                    'validator' => new \Zend\Validator\IsInstanceOf(
+                    'validator' => new Validator\IsInstanceOf(
                         [
                             'className' => Input::class
                         ]
@@ -958,7 +958,7 @@ class BaseInputFilterTest extends TestCase
             return false;
         }));
 
-        $filter = new \Zend\InputFilter\InputFilter;
+        $filter = new InputFilter();
         $filter->add($input)
                ->setData(['foo' => 'nonempty']);
 
@@ -980,7 +980,7 @@ class BaseInputFilterTest extends TestCase
             return false;
         }));
 
-        $filter = new \Zend\InputFilter\InputFilter;
+        $filter = new InputFilter();
         $filter->add($input)
                ->setData(['foo' => 'nonempty']);
 

--- a/test/BaseInputFilterTest.php
+++ b/test/BaseInputFilterTest.php
@@ -20,6 +20,9 @@ use Zend\InputFilter\BaseInputFilter as InputFilter;
 use Zend\Filter;
 use Zend\Validator;
 
+/**
+ * @covers Zend\InputFilter\BaseInputFilter
+ */
 class BaseInputFilterTest extends TestCase
 {
     public function testInputFilterIsEmptyByDefault()

--- a/test/CollectionInputFilterTest.php
+++ b/test/CollectionInputFilterTest.php
@@ -16,6 +16,9 @@ use Zend\InputFilter\Input;
 use Zend\InputFilter\InputFilter;
 use Zend\Validator;
 
+/**
+ * @covers Zend\InputFilter\CollectionInputFilter
+ */
 class CollectionInputFilterTest extends TestCase
 {
     /**

--- a/test/CollectionInputFilterTest.php
+++ b/test/CollectionInputFilterTest.php
@@ -25,6 +25,11 @@ class CollectionInputFilterTest extends TestCase
     use ReplaceableInputInterfaceTestTrait;
     use UnknownInputsCapableInterfaceTestTrait;
 
+    public function testIsASubclassOfInputFilter()
+    {
+        $this->assertInstanceOf(InputFilter::class, $this->createDefaultInputFilter());
+    }
+
     public function getBaseInputFilter()
     {
         $filter = new BaseInputFilter();

--- a/test/CollectionInputFilterTest.php
+++ b/test/CollectionInputFilterTest.php
@@ -21,6 +21,10 @@ use Zend\Validator;
  */
 class CollectionInputFilterTest extends TestCase
 {
+    use InputFilterInterfaceTestTrait;
+    use ReplaceableInputInterfaceTestTrait;
+    use UnknownInputsCapableInterfaceTestTrait;
+
     /**
      * @var CollectionInputFilter
      */
@@ -783,5 +787,22 @@ class CollectionInputFilterTest extends TestCase
         $this->filter->setData($data);
 
         $this->assertFalse($this->filter->isValid());
+    }
+
+    protected function createDefaultInputFilter()
+    {
+        $inputFilter = new CollectionInputFilter();
+
+        return $inputFilter;
+    }
+
+    protected function createDefaultReplaceableInput()
+    {
+        return $this->createDefaultInputFilter();
+    }
+
+    protected function createDefaultUnknownInputsCapable()
+    {
+        return $this->createDefaultInputFilter();
     }
 }

--- a/test/CollectionInputFilterTest.php
+++ b/test/CollectionInputFilterTest.php
@@ -22,7 +22,7 @@ use Zend\Validator;
 class CollectionInputFilterTest extends TestCase
 {
     /**
-     * @var \Zend\InputFilter\CollectionInputFilter
+     * @var CollectionInputFilter
      */
     protected $filter;
 

--- a/test/CollectionInputFilterTest.php
+++ b/test/CollectionInputFilterTest.php
@@ -25,16 +25,6 @@ class CollectionInputFilterTest extends TestCase
     use ReplaceableInputInterfaceTestTrait;
     use UnknownInputsCapableInterfaceTestTrait;
 
-    /**
-     * @var CollectionInputFilter
-     */
-    protected $filter;
-
-    public function setUp()
-    {
-        $this->filter = new CollectionInputFilter();
-    }
-
     public function getBaseInputFilter()
     {
         $filter = new BaseInputFilter();
@@ -113,48 +103,60 @@ class CollectionInputFilterTest extends TestCase
 
     public function testSetInputFilter()
     {
-        $this->filter->setInputFilter(new BaseInputFilter());
-        $this->assertInstanceOf(BaseInputFilter::class, $this->filter->getInputFilter());
+        $inputFilter = $this->createDefaultInputFilter();
+
+        $inputFilter->setInputFilter(new BaseInputFilter());
+        $this->assertInstanceOf(BaseInputFilter::class, $inputFilter->getInputFilter());
     }
 
     public function testGetDefaultInputFilter()
     {
-        $this->assertInstanceOf(BaseInputFilter::class, $this->filter->getInputFilter());
+        $inputFilter = $this->createDefaultInputFilter();
+
+        $this->assertInstanceOf(BaseInputFilter::class, $inputFilter->getInputFilter());
     }
 
     public function testSetCount()
     {
-        $this->filter->setCount(5);
-        $this->assertEquals(5, $this->filter->getCount());
+        $inputFilter = $this->createDefaultInputFilter();
+
+        $inputFilter->setCount(5);
+        $this->assertEquals(5, $inputFilter->getCount());
     }
 
     public function testSetCountBelowZero()
     {
-        $this->filter->setCount(-1);
-        $this->assertEquals(0, $this->filter->getCount());
+        $inputFilter = $this->createDefaultInputFilter();
+
+        $inputFilter->setCount(-1);
+        $this->assertEquals(0, $inputFilter->getCount());
     }
 
     public function testGetCountUsesCountOfCollectionDataWhenNotSet()
     {
+        $inputFilter = $this->createDefaultInputFilter();
+
         $collectionData = [
             ['foo' => 'bar'],
             ['foo' => 'baz']
         ];
 
-        $this->filter->setData($collectionData);
-        $this->assertEquals(2, $this->filter->getCount());
+        $inputFilter->setData($collectionData);
+        $this->assertEquals(2, $inputFilter->getCount());
     }
 
     public function testGetCountUsesSpecifiedCount()
     {
+        $inputFilter = $this->createDefaultInputFilter();
+
         $collectionData = [
             ['foo' => 'bar'],
             ['foo' => 'baz']
         ];
 
-        $this->filter->setCount(3);
-        $this->filter->setData($collectionData);
-        $this->assertEquals(3, $this->filter->getCount());
+        $inputFilter->setCount(3);
+        $inputFilter->setData($collectionData);
+        $this->assertEquals(3, $inputFilter->getCount());
     }
 
     /**
@@ -162,6 +164,8 @@ class CollectionInputFilterTest extends TestCase
      */
     public function testGetCountReturnsRightCountOnConsecutiveCallsWithDifferentData()
     {
+        $inputFilter = $this->createDefaultInputFilter();
+
         $collectionData1 = [
             ['foo' => 'bar'],
             ['foo' => 'baz']
@@ -171,10 +175,10 @@ class CollectionInputFilterTest extends TestCase
             ['foo' => 'bar']
         ];
 
-        $this->filter->setData($collectionData1);
-        $this->assertEquals(2, $this->filter->getCount());
-        $this->filter->setData($collectionData2);
-        $this->assertEquals(1, $this->filter->getCount());
+        $inputFilter->setData($collectionData1);
+        $this->assertEquals(2, $inputFilter->getCount());
+        $inputFilter->setData($collectionData2);
+        $this->assertEquals(1, $inputFilter->getCount());
     }
 
     public function testCanValidateValidData()
@@ -183,9 +187,11 @@ class CollectionInputFilterTest extends TestCase
             $this->markTestSkipped('ext/intl not enabled');
         }
 
-        $this->filter->setInputFilter($this->getBaseInputFilter());
-        $this->filter->setData($this->getValidCollectionData());
-        $this->assertTrue($this->filter->isValid());
+        $inputFilter = $this->createDefaultInputFilter();
+
+        $inputFilter->setInputFilter($this->getBaseInputFilter());
+        $inputFilter->setData($this->getValidCollectionData());
+        $this->assertTrue($inputFilter->isValid());
     }
 
     public function testCanValidateValidDataWithNonConsecutiveKeys()
@@ -194,12 +200,14 @@ class CollectionInputFilterTest extends TestCase
             $this->markTestSkipped('ext/intl not enabled');
         }
 
+        $inputFilter = $this->createDefaultInputFilter();
+
         $collectionData = $this->getValidCollectionData();
         $collectionData[2] = $collectionData[0];
         unset($collectionData[0]);
-        $this->filter->setInputFilter($this->getBaseInputFilter());
-        $this->filter->setData($collectionData);
-        $this->assertTrue($this->filter->isValid());
+        $inputFilter->setInputFilter($this->getBaseInputFilter());
+        $inputFilter->setData($collectionData);
+        $this->assertTrue($inputFilter->isValid());
     }
 
     public function testInvalidDataReturnsFalse()
@@ -207,6 +215,8 @@ class CollectionInputFilterTest extends TestCase
         if (!extension_loaded('intl')) {
             $this->markTestSkipped('ext/intl not enabled');
         }
+
+        $inputFilter = $this->createDefaultInputFilter();
 
         $invalidCollectionData = [
             [
@@ -221,9 +231,9 @@ class CollectionInputFilterTest extends TestCase
             ]
         ];
 
-        $this->filter->setInputFilter($this->getBaseInputFilter());
-        $this->filter->setData($invalidCollectionData);
-        $this->assertFalse($this->filter->isValid());
+        $inputFilter->setInputFilter($this->getBaseInputFilter());
+        $inputFilter->setData($invalidCollectionData);
+        $this->assertFalse($inputFilter->isValid());
     }
 
     public function testDataLessThanCountIsInvalid()
@@ -231,6 +241,8 @@ class CollectionInputFilterTest extends TestCase
         if (!extension_loaded('intl')) {
             $this->markTestSkipped('ext/intl not enabled');
         }
+
+        $inputFilter = $this->createDefaultInputFilter();
 
         $invalidCollectionData = [
             [
@@ -245,10 +257,10 @@ class CollectionInputFilterTest extends TestCase
             ],
         ];
 
-        $this->filter->setCount(2);
-        $this->filter->setInputFilter($this->getBaseInputFilter());
-        $this->filter->setData($invalidCollectionData);
-        $this->assertFalse($this->filter->isValid());
+        $inputFilter->setCount(2);
+        $inputFilter->setInputFilter($this->getBaseInputFilter());
+        $inputFilter->setData($invalidCollectionData);
+        $this->assertFalse($inputFilter->isValid());
     }
 
     public function testGetValues()
@@ -256,6 +268,8 @@ class CollectionInputFilterTest extends TestCase
         if (!extension_loaded('intl')) {
             $this->markTestSkipped('ext/intl not enabled');
         }
+
+        $inputFilter = $this->createDefaultInputFilter();
 
         $expectedData = [
             [
@@ -280,14 +294,14 @@ class CollectionInputFilterTest extends TestCase
             ]
         ];
 
-        $this->filter->setInputFilter($this->getBaseInputFilter());
-        $this->filter->setData($this->getValidCollectionData());
+        $inputFilter->setInputFilter($this->getBaseInputFilter());
+        $inputFilter->setData($this->getValidCollectionData());
 
-        $this->assertTrue($this->filter->isValid());
-        $this->assertEquals($expectedData, $this->filter->getValues());
+        $this->assertTrue($inputFilter->isValid());
+        $this->assertEquals($expectedData, $inputFilter->getValues());
 
-        $this->assertCount(2, $this->filter->getValidInput());
-        foreach ($this->filter->getValidInput() as $validInputs) {
+        $this->assertCount(2, $inputFilter->getValidInput());
+        foreach ($inputFilter->getValidInput() as $validInputs) {
             $this->assertCount(4, $validInputs);
         }
     }
@@ -297,6 +311,8 @@ class CollectionInputFilterTest extends TestCase
         if (!extension_loaded('intl')) {
             $this->markTestSkipped('ext/intl not enabled');
         }
+
+        $inputFilter = $this->createDefaultInputFilter();
 
         $expectedData = [
             [
@@ -321,11 +337,11 @@ class CollectionInputFilterTest extends TestCase
             ]
         ];
 
-        $this->filter->setInputFilter($this->getBaseInputFilter());
-        $this->filter->setData($this->getValidCollectionData());
+        $inputFilter->setInputFilter($this->getBaseInputFilter());
+        $inputFilter->setData($this->getValidCollectionData());
 
-        $this->assertTrue($this->filter->isValid());
-        $this->assertEquals($expectedData, $this->filter->getRawValues());
+        $this->assertTrue($inputFilter->isValid());
+        $this->assertEquals($expectedData, $inputFilter->getRawValues());
     }
 
     public function testGetMessagesForInvalidInputs()
@@ -333,6 +349,8 @@ class CollectionInputFilterTest extends TestCase
         if (!extension_loaded('intl')) {
             $this->markTestSkipped('ext/intl not enabled');
         }
+
+        $inputFilter = $this->createDefaultInputFilter();
 
         $invalidCollectionData = [
             [
@@ -367,17 +385,17 @@ class CollectionInputFilterTest extends TestCase
             ],
         ];
 
-        $this->filter->setInputFilter($this->getBaseInputFilter());
-        $this->filter->setData($invalidCollectionData);
+        $inputFilter->setInputFilter($this->getBaseInputFilter());
+        $inputFilter->setData($invalidCollectionData);
 
-        $this->assertFalse($this->filter->isValid());
+        $this->assertFalse($inputFilter->isValid());
 
-        $this->assertCount(3, $this->filter->getInvalidInput());
-        foreach ($this->filter->getInvalidInput() as $invalidInputs) {
+        $this->assertCount(3, $inputFilter->getInvalidInput());
+        foreach ($inputFilter->getInvalidInput() as $invalidInputs) {
             $this->assertCount(1, $invalidInputs);
         }
 
-        $messages = $this->filter->getMessages();
+        $messages = $inputFilter->getMessages();
 
         $this->assertCount(3, $messages);
         $this->assertArrayHasKey('foo', $messages[0]);
@@ -394,6 +412,8 @@ class CollectionInputFilterTest extends TestCase
         if (!extension_loaded('intl')) {
             $this->markTestSkipped('ext/intl not enabled');
         }
+
+        $inputFilter = $this->createDefaultInputFilter();
 
         // forms set an array of identical validation groups for each set of data
         $formValidationGroup = [
@@ -426,11 +446,11 @@ class CollectionInputFilterTest extends TestCase
             ]
         ];
 
-        $this->filter->setInputFilter($this->getBaseInputFilter());
-        $this->filter->setData($data);
-        $this->filter->setValidationGroup($formValidationGroup);
+        $inputFilter->setInputFilter($this->getBaseInputFilter());
+        $inputFilter->setData($data);
+        $inputFilter->setValidationGroup($formValidationGroup);
 
-        $this->assertTrue($this->filter->isValid());
+        $this->assertTrue($inputFilter->isValid());
     }
 
     public function testEmptyCollectionIsValidByDefault()
@@ -439,12 +459,14 @@ class CollectionInputFilterTest extends TestCase
             $this->markTestSkipped('ext/intl not enabled');
         }
 
+        $inputFilter = $this->createDefaultInputFilter();
+
         $data = [];
 
-        $this->filter->setInputFilter($this->getBaseInputFilter());
-        $this->filter->setData($data);
+        $inputFilter->setInputFilter($this->getBaseInputFilter());
+        $inputFilter->setData($data);
 
-        $this->assertTrue($this->filter->isValid());
+        $this->assertTrue($inputFilter->isValid());
     }
 
     public function testEmptyCollectionIsNotValidIfRequired()
@@ -453,23 +475,29 @@ class CollectionInputFilterTest extends TestCase
             $this->markTestSkipped('ext/intl not enabled');
         }
 
+        $inputFilter = $this->createDefaultInputFilter();
+
         $data = [];
 
-        $this->filter->setInputFilter($this->getBaseInputFilter());
-        $this->filter->setData($data);
-        $this->filter->setIsRequired(true);
+        $inputFilter->setInputFilter($this->getBaseInputFilter());
+        $inputFilter->setData($data);
+        $inputFilter->setIsRequired(true);
 
-        $this->assertFalse($this->filter->isValid());
+        $this->assertFalse($inputFilter->isValid());
     }
 
     public function testSetRequired()
     {
-        $this->filter->setIsRequired(true);
-        $this->assertEquals(true, $this->filter->getIsRequired());
+        $inputFilter = $this->createDefaultInputFilter();
+
+        $inputFilter->setIsRequired(true);
+        $this->assertEquals(true, $inputFilter->getIsRequired());
     }
 
     public function testNonRequiredFieldsAreValidated()
     {
+        $inputFilter = $this->createDefaultInputFilter();
+
         $invalidCollectionData = [
             [
                 'foo' => ' bazbattoolong ',
@@ -483,12 +511,12 @@ class CollectionInputFilterTest extends TestCase
             ]
         ];
 
-        $this->filter->setInputFilter($this->getBaseInputFilter());
-        $this->filter->setData($invalidCollectionData);
+        $inputFilter->setInputFilter($this->getBaseInputFilter());
+        $inputFilter->setData($invalidCollectionData);
 
-        $this->assertFalse($this->filter->isValid());
-        $this->assertCount(2, current($this->filter->getInvalidInput()));
-        $this->assertArrayHasKey('baz', current($this->filter->getMessages()));
+        $this->assertFalse($inputFilter->isValid());
+        $this->assertCount(2, current($inputFilter->getInvalidInput()));
+        $this->assertArrayHasKey('baz', current($inputFilter->getMessages()));
     }
 
     public function testNestedCollectionWithEmptyChild()
@@ -781,12 +809,14 @@ class CollectionInputFilterTest extends TestCase
 
     public function testInvalidCollectionIsNotValid()
     {
+        $inputFilter = $this->createDefaultInputFilter();
+
         $data = 1;
 
-        $this->filter->setInputFilter($this->getBaseInputFilter());
-        $this->filter->setData($data);
+        $inputFilter->setInputFilter($this->getBaseInputFilter());
+        $inputFilter->setData($data);
 
-        $this->assertFalse($this->filter->isValid());
+        $this->assertFalse($inputFilter->isValid());
     }
 
     protected function createDefaultInputFilter()

--- a/test/CollectionInputFilterTest.php
+++ b/test/CollectionInputFilterTest.php
@@ -524,13 +524,13 @@ class CollectionInputFilterTest extends TestCase
         $items_inputfilter = new BaseInputFilter();
         $items_inputfilter->add(new Input(), 'id')
                           ->add(new Input(), 'type');
-        $items = new CollectionInputFilter();
+        $items = $this->createDefaultInputFilter();
         $items->setInputFilter($items_inputfilter);
 
         $groups_inputfilter = new BaseInputFilter();
         $groups_inputfilter->add(new Input(), 'group_class')
                            ->add($items, 'items');
-        $groups = new CollectionInputFilter();
+        $groups = $this->createDefaultInputFilter();
         $groups->setInputFilter($groups_inputfilter);
 
         $inputFilter = new BaseInputFilter();
@@ -616,13 +616,13 @@ class CollectionInputFilterTest extends TestCase
         $items_inputfilter = new BaseInputFilter();
         $items_inputfilter->add(new Input(), 'id')
                           ->add(new Input(), 'type');
-        $items = new CollectionInputFilter();
+        $items = $this->createDefaultInputFilter();
         $items->setInputFilter($items_inputfilter);
 
         $groups_inputfilter = new BaseInputFilter();
         $groups_inputfilter->add(new Input(), 'group_class')
                            ->add($items, 'items');
-        $groups = new CollectionInputFilter();
+        $groups = $this->createDefaultInputFilter();
         $groups->setInputFilter($groups_inputfilter);
 
         $inputFilter = new BaseInputFilter();
@@ -677,13 +677,13 @@ class CollectionInputFilterTest extends TestCase
         $items_inputfilter = new BaseInputFilter();
         $items_inputfilter->add(new Input(), 'id')
                           ->add(new Input(), 'type');
-        $items = new CollectionInputFilter();
+        $items = $this->createDefaultInputFilter();
         $items->setInputFilter($items_inputfilter);
 
         $groups_inputfilter = new BaseInputFilter();
         $groups_inputfilter->add(new Input(), 'group_class')
                            ->add($items, 'items');
-        $groups = new CollectionInputFilter();
+        $groups = $this->createDefaultInputFilter();
         $groups->setInputFilter($groups_inputfilter);
 
         $inputFilter = new BaseInputFilter();
@@ -763,14 +763,14 @@ class CollectionInputFilterTest extends TestCase
     {
         $firstInputFilter = new InputFilter();
 
-        $firstCollection = new CollectionInputFilter();
+        $firstCollection = $this->createDefaultInputFilter();
         $firstCollection->setInputFilter($firstInputFilter);
 
         $someInput = new Input('input');
         $secondInputFilter = new InputFilter();
         $secondInputFilter->add($someInput, 'input');
 
-        $secondCollection = new CollectionInputFilter();
+        $secondCollection = $this->createDefaultInputFilter();
         $secondCollection->setInputFilter($secondInputFilter);
         if (!is_null($count)) {
             $secondCollection->setCount($count);

--- a/test/CollectionInputFilterTest.php
+++ b/test/CollectionInputFilterTest.php
@@ -110,12 +110,12 @@ class CollectionInputFilterTest extends TestCase
     public function testSetInputFilter()
     {
         $this->filter->setInputFilter(new BaseInputFilter());
-        $this->assertInstanceOf('Zend\InputFilter\BaseInputFilter', $this->filter->getInputFilter());
+        $this->assertInstanceOf(BaseInputFilter::class, $this->filter->getInputFilter());
     }
 
     public function testGetDefaultInputFilter()
     {
-        $this->assertInstanceOf('Zend\InputFilter\BaseInputFilter', $this->filter->getInputFilter());
+        $this->assertInstanceOf(BaseInputFilter::class, $this->filter->getInputFilter());
     }
 
     public function testSetCount()

--- a/test/CollectionInputFilterTest.php
+++ b/test/CollectionInputFilterTest.php
@@ -10,8 +10,10 @@
 namespace ZendTest\InputFilter;
 
 use PHPUnit_Framework_TestCase as TestCase;
+use stdClass;
 use Zend\InputFilter\BaseInputFilter;
 use Zend\InputFilter\CollectionInputFilter;
+use Zend\InputFilter\Exception\RuntimeException;
 use Zend\InputFilter\Input;
 use Zend\InputFilter\InputFilter;
 use Zend\Validator;
@@ -28,6 +30,18 @@ class CollectionInputFilterTest extends TestCase
     public function testIsASubclassOfInputFilter()
     {
         $this->assertInstanceOf(InputFilter::class, $this->createDefaultInputFilter());
+    }
+
+    public function testSetDataWithInvalidDataTypeThrowsInvalidArgumentException()
+    {
+        $filter = $this->createDefaultInputFilter();
+
+        $this->setExpectedException(
+            RuntimeException::class,
+            'expects an instance of Zend\InputFilter\BaseInputFilter; received "stdClass"'
+        );
+        /** @noinspection PhpParamsInspection */
+        $filter->setInputFilter(new stdClass());
     }
 
     public function getBaseInputFilter()

--- a/test/EmptyContextInterfaceTestTrait.php
+++ b/test/EmptyContextInterfaceTestTrait.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace ZendTest\InputFilter;
+
+use PHPUnit_Framework_Assert as Assert;
+use Zend\InputFilter\EmptyContextInterface;
+
+/**
+ * Compliance test methods for `Zend\InputFilter\EmptyContextInterface` implementations.
+ */
+trait EmptyContextInterfaceTestTrait
+{
+    public function testImplementsEmptyContextInterface()
+    {
+        Assert::assertInstanceOf(EmptyContextInterface::class, $this->createDefaultEmptyContext());
+    }
+
+    /**
+     * @return EmptyContextInterface
+     */
+    abstract protected function createDefaultEmptyContext();
+}

--- a/test/EmptyContextInterfaceTestTrait.php
+++ b/test/EmptyContextInterfaceTestTrait.php
@@ -15,6 +15,28 @@ trait EmptyContextInterfaceTestTrait
         Assert::assertInstanceOf(EmptyContextInterface::class, $this->createDefaultEmptyContext());
     }
 
+    public function setContinueIfEmptyProvider()
+    {
+        return [
+            // Description => [$continueIfEmpty]
+            'Enable' => [true],
+            'Disable' => [false],
+        ];
+    }
+
+    /**
+     * @dataProvider setContinueIfEmptyProvider
+     */
+    public function testSetContinueIfEmpty($continueIfEmpty)
+    {
+        $input = $this->createDefaultEmptyContext();
+
+        $return = $input->setContinueIfEmpty($continueIfEmpty);
+        Assert::assertSame($input, $return, 'setContinueIfEmpty() must return it self');
+
+        Assert::assertEquals($continueIfEmpty, $input->continueIfEmpty(), 'continueIfEmpty() value not match');
+    }
+
     /**
      * @return EmptyContextInterface
      */

--- a/test/FactoryTest.php
+++ b/test/FactoryTest.php
@@ -192,6 +192,38 @@ class FactoryTest extends TestCase
         );
     }
 
+    public function inputTypeSpecificationProvider()
+    {
+        return [
+            // Description => [$specificationKey]
+            'continue_if_empty' => ['continue_if_empty'],
+            'fallback_value' => ['fallback_value'],
+        ];
+    }
+
+    /**
+     * @dataProvider inputTypeSpecificationProvider
+     */
+    public function testCreateInputWithSpecificInputTypeSettingsThrowException($specificationKey)
+    {
+        $factory = $this->createDefaultFactory();
+        $type = 'pluginInputInterface';
+
+        $pluginManager = $this->createInputFilterPluginManagerMockForPlugin($type, $this->getMock(InputInterface::class));
+        $factory->setInputFilterManager($pluginManager);
+
+        $this->setExpectedException(
+            RuntimeException::class,
+            sprintf('"%s" can only set to inputs of type "Zend\InputFilter\Input"', $specificationKey)
+        );
+        $factory->createInput(
+            [
+                'type' => $type,
+                $specificationKey => true,
+            ]
+        );
+    }
+
     public function testCreateInputWithValidatorsAsAnCollectionOfInvalidTypesThrowException()
     {
         $factory = $this->createDefaultFactory();

--- a/test/FactoryTest.php
+++ b/test/FactoryTest.php
@@ -11,10 +11,15 @@ namespace ZendTest\InputFilter;
 
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Filter;
+use Zend\InputFilter\CollectionInputFilter;
 use Zend\InputFilter\Factory;
 use Zend\InputFilter\Input;
 use Zend\InputFilter\InputFilter;
+use Zend\InputFilter\InputFilterInterface;
 use Zend\InputFilter\InputFilterPluginManager;
+use Zend\InputFilter\InputFilterProviderInterface;
+use Zend\InputFilter\InputInterface;
+use Zend\InputFilter\InputProviderInterface;
 use Zend\ServiceManager;
 use Zend\Validator;
 
@@ -26,13 +31,13 @@ class FactoryTest extends TestCase
     public function testFactoryComposesFilterChainByDefault()
     {
         $factory = new Factory();
-        $this->assertInstanceOf('Zend\Filter\FilterChain', $factory->getDefaultFilterChain());
+        $this->assertInstanceOf(Filter\FilterChain::class, $factory->getDefaultFilterChain());
     }
 
     public function testFactoryComposesValidatorChainByDefault()
     {
         $factory = new Factory();
-        $this->assertInstanceOf('Zend\Validator\ValidatorChain', $factory->getDefaultValidatorChain());
+        $this->assertInstanceOf(Validator\ValidatorChain::class, $factory->getDefaultValidatorChain());
     }
 
     public function testFactoryAllowsInjectingFilterChain()
@@ -61,7 +66,7 @@ class FactoryTest extends TestCase
         $input = $factory->createInput([
             'name' => 'foo',
         ]);
-        $this->assertInstanceOf('Zend\InputFilter\InputInterface', $input);
+        $this->assertInstanceOf(InputInterface::class, $input);
         $inputFilterChain = $input->getFilterChain();
         $this->assertNotSame($filterChain, $inputFilterChain);
         $this->assertSame($pluginManager, $inputFilterChain->getPluginManager());
@@ -77,7 +82,7 @@ class FactoryTest extends TestCase
         $input = $factory->createInput([
             'name' => 'foo',
         ]);
-        $this->assertInstanceOf('Zend\InputFilter\InputInterface', $input);
+        $this->assertInstanceOf(InputInterface::class, $input);
         $inputValidatorChain = $input->getValidatorChain();
         $this->assertNotSame($validatorChain, $inputValidatorChain);
         $this->assertSame($validatorPlugins, $inputValidatorChain->getPluginManager());
@@ -100,10 +105,10 @@ class FactoryTest extends TestCase
                 'name' => 'foo',
             ],
         ]);
-        $this->assertInstanceOf('Zend\InputFilter\InputFilterInterface', $inputFilter);
+        $this->assertInstanceOf(InputFilterInterface::class, $inputFilter);
         $this->assertEquals(1, count($inputFilter));
         $input = $inputFilter->get('foo');
-        $this->assertInstanceOf('Zend\InputFilter\InputInterface', $input);
+        $this->assertInstanceOf(InputInterface::class, $input);
         $inputFilterChain    = $input->getFilterChain();
         $inputValidatorChain = $input->getValidatorChain();
         $this->assertSame($filterPlugins, $inputFilterChain->getPluginManager());
@@ -129,20 +134,20 @@ class FactoryTest extends TestCase
                 ],
             ],
         ]);
-        $this->assertInstanceOf('Zend\InputFilter\InputInterface', $input);
+        $this->assertInstanceOf(InputInterface::class, $input);
         $this->assertEquals('foo', $input->getName());
         $chain = $input->getFilterChain();
         $index = 0;
         foreach ($chain as $filter) {
             switch ($index) {
                 case 0:
-                    $this->assertInstanceOf('Zend\Filter\StringTrim', $filter);
+                    $this->assertInstanceOf(Filter\StringTrim::class, $filter);
                     break;
                 case 1:
                     $this->assertSame($htmlEntities, $filter);
                     break;
                 case 2:
-                    $this->assertInstanceOf('Zend\Filter\StringToLower', $filter);
+                    $this->assertInstanceOf(Filter\StringToLower::class, $filter);
                     $this->assertEquals('ISO-8859-1', $filter->getEncoding());
                     break;
                 default:
@@ -172,20 +177,20 @@ class FactoryTest extends TestCase
                 ],
             ],
         ]);
-        $this->assertInstanceOf('Zend\InputFilter\InputInterface', $input);
+        $this->assertInstanceOf(InputInterface::class, $input);
         $this->assertEquals('foo', $input->getName());
         $chain = $input->getValidatorChain();
         $index = 0;
         foreach ($chain as $validator) {
             switch ($index) {
                 case 0:
-                    $this->assertInstanceOf('Zend\Validator\NotEmpty', $validator);
+                    $this->assertInstanceOf(Validator\NotEmpty::class, $validator);
                     break;
                 case 1:
                     $this->assertSame($digits, $validator);
                     break;
                 case 2:
-                    $this->assertInstanceOf('Zend\Validator\StringLength', $validator);
+                    $this->assertInstanceOf(Validator\StringLength::class, $validator);
                     $this->assertEquals(3, $validator->getMin());
                     $this->assertEquals(5, $validator->getMax());
                     break;
@@ -204,7 +209,7 @@ class FactoryTest extends TestCase
             'required' => false,
             'allow_empty' => false,
         ]);
-        $this->assertInstanceOf('Zend\InputFilter\InputInterface', $input);
+        $this->assertInstanceOf(InputInterface::class, $input);
         $this->assertFalse($input->isRequired());
         $this->assertFalse($input->allowEmpty());
     }
@@ -216,7 +221,7 @@ class FactoryTest extends TestCase
             'name'        => 'foo',
             'allow_empty' => true,
         ]);
-        $this->assertInstanceOf('Zend\InputFilter\InputInterface', $input);
+        $this->assertInstanceOf(InputInterface::class, $input);
         $this->assertTrue($input->allowEmpty());
         $this->assertFalse($input->isRequired());
     }
@@ -227,7 +232,7 @@ class FactoryTest extends TestCase
         $input   = $factory->createInput([
             'name'        => 'foo',
         ]);
-        $this->assertInstanceOf('Zend\InputFilter\InputInterface', $input);
+        $this->assertInstanceOf(InputInterface::class, $input);
         $this->assertEquals('foo', $input->getName());
     }
 
@@ -238,7 +243,7 @@ class FactoryTest extends TestCase
             'name'              => 'foo',
             'continue_if_empty' => true,
         ]);
-        $this->assertInstanceOf('Zend\InputFilter\InputInterface', $input);
+        $this->assertInstanceOf(InputInterface::class, $input);
         $this->assertTrue($input->continueIfEmpty());
     }
 
@@ -251,7 +256,7 @@ class FactoryTest extends TestCase
             'foo' => $input
         ]);
 
-        $this->assertInstanceOf('Zend\InputFilter\InputFilterInterface', $inputFilter);
+        $this->assertInstanceOf(InputFilterInterface::class, $inputFilter);
         $this->assertTrue($inputFilter->has('foo'));
         $this->assertEquals($input, $inputFilter->get('foo'));
     }
@@ -265,7 +270,7 @@ class FactoryTest extends TestCase
             'foo' => $input
         ]);
 
-        $this->assertInstanceOf('Zend\InputFilter\InputFilterInterface', $inputFilter);
+        $this->assertInstanceOf(InputFilterInterface::class, $inputFilter);
         $this->assertTrue($inputFilter->has('foo'));
         $this->assertEquals($input, $inputFilter->get('foo'));
     }
@@ -305,7 +310,7 @@ class FactoryTest extends TestCase
                 ],
             ],
             'baz' => [
-                'type'   => 'Zend\InputFilter\InputFilter',
+                'type'   => InputFilter::class,
                 'foo' => [
                     'name'       => 'foo',
                     'required'   => false,
@@ -346,7 +351,7 @@ class FactoryTest extends TestCase
                 'continue_if_empty' => true,
             ],
         ]);
-        $this->assertInstanceOf('Zend\InputFilter\InputFilter', $inputFilter);
+        $this->assertInstanceOf(InputFilter::class, $inputFilter);
         $this->assertEquals(5, count($inputFilter));
 
         foreach (['foo', 'bar', 'baz', 'bat', 'zomg'] as $name) {
@@ -354,24 +359,24 @@ class FactoryTest extends TestCase
 
             switch ($name) {
                 case 'foo':
-                    $this->assertInstanceOf('Zend\InputFilter\Input', $input);
+                    $this->assertInstanceOf(Input::class, $input);
                     $this->assertFalse($input->isRequired());
                     $this->assertEquals(2, count($input->getValidatorChain()));
                     break;
                 case 'bar':
-                    $this->assertInstanceOf('Zend\InputFilter\Input', $input);
+                    $this->assertInstanceOf(Input::class, $input);
                     $this->assertTrue($input->allowEmpty());
                     $this->assertEquals(2, count($input->getFilterChain()));
                     break;
                 case 'baz':
-                    $this->assertInstanceOf('Zend\InputFilter\InputFilter', $input);
+                    $this->assertInstanceOf(InputFilter::class, $input);
                     $this->assertEquals(2, count($input));
                     $foo = $input->get('foo');
-                    $this->assertInstanceOf('Zend\InputFilter\Input', $foo);
+                    $this->assertInstanceOf(Input::class, $foo);
                     $this->assertFalse($foo->isRequired());
                     $this->assertEquals(2, count($foo->getValidatorChain()));
                     $bar = $input->get('bar');
-                    $this->assertInstanceOf('Zend\InputFilter\Input', $bar);
+                    $this->assertInstanceOf(Input::class, $bar);
                     $this->assertTrue($bar->allowEmpty());
                     $this->assertEquals(2, count($bar->getFilterChain()));
                     break;
@@ -380,7 +385,7 @@ class FactoryTest extends TestCase
                     $this->assertEquals('bat', $input->getName());
                     break;
                 case 'zomg':
-                    $this->assertInstanceOf('Zend\InputFilter\Input', $input);
+                    $this->assertInstanceOf(Input::class, $input);
                     $this->assertTrue($input->continueIfEmpty());
             }
         }
@@ -394,7 +399,7 @@ class FactoryTest extends TestCase
         ]);
 
         $this->assertTrue($inputFilter->has('foo'));
-        $this->assertInstanceOf('Zend\InputFilter\Input', $inputFilter->get('foo'));
+        $this->assertInstanceOf(Input::class, $inputFilter->get('foo'));
     }
 
     public function testFactoryAllowsPassingValidatorChainsInInputSpec()
@@ -405,7 +410,7 @@ class FactoryTest extends TestCase
             'name'       => 'foo',
             'validators' => $chain,
         ]);
-        $this->assertInstanceOf('Zend\InputFilter\InputInterface', $input);
+        $this->assertInstanceOf(InputInterface::class, $input);
         $test = $input->getValidatorChain();
         $this->assertSame($chain, $test);
     }
@@ -418,7 +423,7 @@ class FactoryTest extends TestCase
             'name'    => 'foo',
             'filters' => $chain,
         ]);
-        $this->assertInstanceOf('Zend\InputFilter\InputInterface', $input);
+        $this->assertInstanceOf(InputInterface::class, $input);
         $test = $input->getFilterChain();
         $this->assertSame($chain, $test);
     }
@@ -428,14 +433,14 @@ class FactoryTest extends TestCase
         $factory = new Factory();
 
         $inputFilter = $factory->createInputFilter([
-            'type'        => 'Zend\InputFilter\CollectionInputFilter',
+            'type'        => CollectionInputFilter::class,
             'required'    => true,
             'inputfilter' => new InputFilter(),
             'count'       => 3,
         ]);
 
-        $this->assertInstanceOf('Zend\InputFilter\CollectionInputFilter', $inputFilter);
-        $this->assertInstanceOf('Zend\InputFilter\InputFilter', $inputFilter->getInputFilter());
+        $this->assertInstanceOf(CollectionInputFilter::class, $inputFilter);
+        $this->assertInstanceOf(InputFilter::class, $inputFilter->getInputFilter());
         $this->assertTrue($inputFilter->getIsRequired());
         $this->assertEquals(3, $inputFilter->getCount());
     }
@@ -480,13 +485,13 @@ class FactoryTest extends TestCase
         foreach ($input->getFilterChain()->getFilters() as $filter) {
             switch ($index) {
                 case 0:
-                    $this->assertInstanceOf('Zend\Filter\StringToUpper', $filter);
+                    $this->assertInstanceOf(Filter\StringToUpper::class, $filter);
                     break;
                 case 1:
-                    $this->assertInstanceOf('Zend\Filter\StringToLower', $filter);
+                    $this->assertInstanceOf(Filter\StringToLower::class, $filter);
                     break;
                 case 2:
-                    $this->assertInstanceOf('Zend\Filter\StringTrim', $filter);
+                    $this->assertInstanceOf(Filter\StringTrim::class, $filter);
                     break;
             }
             $index++;
@@ -505,7 +510,7 @@ class FactoryTest extends TestCase
             ]
         );
 
-        $this->assertInstanceOf('Zend\InputFilter\InputFilter', $inputFilter);
+        $this->assertInstanceOf(InputFilter::class, $inputFilter);
         $this->assertTrue($inputFilter->has('type'));
     }
 
@@ -516,7 +521,7 @@ class FactoryTest extends TestCase
             'type'        => 'collection',
             'input_filter' => new InputFilter(),
         ]);
-        $this->assertInstanceOf('ZendTest\InputFilter\TestAsset\CustomFactory', $inputFilter->getFactory());
+        $this->assertInstanceOf(TestAsset\CustomFactory::class, $inputFilter->getFactory());
     }
 
     /**
@@ -527,7 +532,7 @@ class FactoryTest extends TestCase
         $factory = new Factory();
         $input   = $factory->createInput([
             'name'          => 'test',
-            'type'          => 'Zend\InputFilter\Input',
+            'type'          => Input::class,
             'error_message' => 'Custom error message',
         ]);
         $this->assertEquals('Custom error message', $input->getErrorMessage());
@@ -543,11 +548,11 @@ class FactoryTest extends TestCase
         $factory = new Factory();
         $factory->setInputFilterManager($inputFilterManager);
         $this->assertInstanceOf(
-            'Zend\Validator\ValidatorPluginManager',
+            Validator\ValidatorPluginManager::class,
             $factory->getDefaultValidatorChain()->getPluginManager()
         );
         $this->assertInstanceOf(
-            'Zend\Filter\FilterPluginManager',
+            Filter\FilterPluginManager::class,
             $factory->getDefaultFilterChain()->getPluginManager()
         );
     }
@@ -595,7 +600,7 @@ class FactoryTest extends TestCase
             ],
         ]);
 
-        $this->assertInstanceOf('Zend\InputFilter\InputFilter', $inputFilter);
+        $this->assertInstanceOf(InputFilter::class, $inputFilter);
         $this->assertEquals(2, count($inputFilter));
         $this->assertTrue($inputFilter->has('foo'));
         $this->assertFalse($inputFilter->has('bar'));
@@ -607,8 +612,8 @@ class FactoryTest extends TestCase
      */
     public function testCanCreateInputFromProvider()
     {
-        /* @group $provider \Zend\InputFilter\InputProviderInterface|\PHPUnit_Framework_MockObject_MockObject */
-        $provider = $this->getMock('Zend\InputFilter\InputProviderInterface', ['getInputSpecification']);
+        /** @var InputProviderInterface|\PHPUnit_Framework_MockObject_MockObject $provider */
+        $provider = $this->getMock(InputProviderInterface::class, ['getInputSpecification']);
 
         $provider
             ->expects($this->any())
@@ -618,7 +623,7 @@ class FactoryTest extends TestCase
         $factory = new Factory();
         $input   = $factory->createInput($provider);
 
-        $this->assertInstanceOf('Zend\InputFilter\InputInterface', $input);
+        $this->assertInstanceOf(InputInterface::class, $input);
     }
 
     /**
@@ -626,9 +631,9 @@ class FactoryTest extends TestCase
      */
     public function testCanCreateInputFilterFromProvider()
     {
-        /* @group $provider \Zend\InputFilter\InputFilterProviderInterface|\PHPUnit_Framework_MockObject_MockObject */
+        /** @var InputFilterProviderInterface|\PHPUnit_Framework_MockObject_MockObject $provider */
         $provider = $this->getMock(
-            'Zend\InputFilter\InputFilterProviderInterface',
+            InputFilterProviderInterface::class,
             ['getInputFilterSpecification']
         );
         $provider
@@ -648,7 +653,7 @@ class FactoryTest extends TestCase
         $factory     = new Factory();
         $inputFilter = $factory->createInputFilter($provider);
 
-        $this->assertInstanceOf('Zend\InputFilter\InputFilterInterface', $inputFilter);
+        $this->assertInstanceOf(InputFilterInterface::class, $inputFilter);
     }
 
     public function testSuggestedTypeMayBePluginNameInInputFilterPluginManager()
@@ -663,7 +668,7 @@ class FactoryTest extends TestCase
         ]);
         $this->assertSame('bar', $input->getName());
 
-        $this->setExpectedException('Zend\Filter\Exception\RuntimeException');
+        $this->setExpectedException(Filter\Exception\RuntimeException::class);
         $factory->createInput([
             'type' => 'foo'
         ]);

--- a/test/FactoryTest.php
+++ b/test/FactoryTest.php
@@ -433,6 +433,7 @@ class FactoryTest extends TestCase
     {
         $factory = new Factory();
 
+        /** @var CollectionInputFilter $inputFilter */
         $inputFilter = $factory->createInputFilter([
             'type'        => CollectionInputFilter::class,
             'required'    => true,
@@ -518,6 +519,7 @@ class FactoryTest extends TestCase
     public function testCustomFactoryInCollection()
     {
         $factory = new TestAsset\CustomFactory();
+        /** @var CollectionInputFilter $inputFilter */
         $inputFilter = $factory->createInputFilter([
             'type'        => 'collection',
             'input_filter' => new InputFilter(),

--- a/test/FactoryTest.php
+++ b/test/FactoryTest.php
@@ -31,19 +31,19 @@ class FactoryTest extends TestCase
 {
     public function testFactoryComposesFilterChainByDefault()
     {
-        $factory = new Factory();
+        $factory = $this->createDefaultFactory();
         $this->assertInstanceOf(Filter\FilterChain::class, $factory->getDefaultFilterChain());
     }
 
     public function testFactoryComposesValidatorChainByDefault()
     {
-        $factory = new Factory();
+        $factory = $this->createDefaultFactory();
         $this->assertInstanceOf(Validator\ValidatorChain::class, $factory->getDefaultValidatorChain());
     }
 
     public function testFactoryAllowsInjectingFilterChain()
     {
-        $factory     = new Factory();
+        $factory     = $this->createDefaultFactory();
         $filterChain = new Filter\FilterChain();
         $factory->setDefaultFilterChain($filterChain);
         $this->assertSame($filterChain, $factory->getDefaultFilterChain());
@@ -51,7 +51,7 @@ class FactoryTest extends TestCase
 
     public function testFactoryAllowsInjectingValidatorChain()
     {
-        $factory        = new Factory();
+        $factory        = $this->createDefaultFactory();
         $validatorChain = new Validator\ValidatorChain();
         $factory->setDefaultValidatorChain($validatorChain);
         $this->assertSame($validatorChain, $factory->getDefaultValidatorChain());
@@ -59,7 +59,7 @@ class FactoryTest extends TestCase
 
     public function testFactoryUsesComposedFilterChainWhenCreatingNewInputObjects()
     {
-        $factory       = new Factory();
+        $factory       = $this->createDefaultFactory();
         $filterChain   = new Filter\FilterChain();
         $pluginManager = new Filter\FilterPluginManager();
         $filterChain->setPluginManager($pluginManager);
@@ -75,7 +75,7 @@ class FactoryTest extends TestCase
 
     public function testFactoryUsesComposedValidatorChainWhenCreatingNewInputObjects()
     {
-        $factory          = new Factory();
+        $factory          = $this->createDefaultFactory();
         $validatorChain   = new Validator\ValidatorChain();
         $validatorPlugins = new Validator\ValidatorPluginManager();
         $validatorChain->setPluginManager($validatorPlugins);
@@ -91,7 +91,7 @@ class FactoryTest extends TestCase
 
     public function testFactoryInjectsComposedFilterAndValidatorChainsIntoInputObjectsWhenCreatingNewInputFilterObjects()
     {
-        $factory          = new Factory();
+        $factory          = $this->createDefaultFactory();
         $filterPlugins    = new Filter\FilterPluginManager();
         $validatorPlugins = new Validator\ValidatorPluginManager();
         $filterChain      = new Filter\FilterChain();
@@ -118,7 +118,7 @@ class FactoryTest extends TestCase
 
     public function testFactoryWillCreateInputWithSuggestedFilters()
     {
-        $factory      = new Factory();
+        $factory      = $this->createDefaultFactory();
         $htmlEntities = new Filter\HtmlEntities();
         $input = $factory->createInput([
             'name'    => 'foo',
@@ -160,7 +160,7 @@ class FactoryTest extends TestCase
 
     public function testFactoryWillCreateInputWithSuggestedValidators()
     {
-        $factory = new Factory();
+        $factory = $this->createDefaultFactory();
         $digits  = new Validator\Digits();
         $input = $factory->createInput([
             'name'       => 'foo',
@@ -204,7 +204,7 @@ class FactoryTest extends TestCase
 
     public function testFactoryWillCreateInputWithSuggestedRequiredFlagAndAlternativeAllowEmptyFlag()
     {
-        $factory = new Factory();
+        $factory = $this->createDefaultFactory();
         $input   = $factory->createInput([
             'name'     => 'foo',
             'required' => false,
@@ -217,7 +217,7 @@ class FactoryTest extends TestCase
 
     public function testFactoryWillCreateInputWithSuggestedAllowEmptyFlagAndImpliesRequiredFlag()
     {
-        $factory = new Factory();
+        $factory = $this->createDefaultFactory();
         $input   = $factory->createInput([
             'name'        => 'foo',
             'allow_empty' => true,
@@ -229,7 +229,7 @@ class FactoryTest extends TestCase
 
     public function testFactoryWillCreateInputWithSuggestedName()
     {
-        $factory = new Factory();
+        $factory = $this->createDefaultFactory();
         $input   = $factory->createInput([
             'name'        => 'foo',
         ]);
@@ -239,7 +239,7 @@ class FactoryTest extends TestCase
 
     public function testFactoryWillCreateInputWithContinueIfEmptyFlag()
     {
-        $factory = new Factory();
+        $factory = $this->createDefaultFactory();
         $input = $factory->createInput([
             'name'              => 'foo',
             'continue_if_empty' => true,
@@ -250,7 +250,7 @@ class FactoryTest extends TestCase
 
     public function testFactoryAcceptsInputInterface()
     {
-        $factory = new Factory();
+        $factory = $this->createDefaultFactory();
         $input = new Input();
 
         $inputFilter = $factory->createInputFilter([
@@ -264,7 +264,7 @@ class FactoryTest extends TestCase
 
     public function testFactoryAcceptsInputFilterInterface()
     {
-        $factory = new Factory();
+        $factory = $this->createDefaultFactory();
         $input = new InputFilter();
 
         $inputFilter = $factory->createInputFilter([
@@ -278,7 +278,7 @@ class FactoryTest extends TestCase
 
     public function testFactoryWillCreateInputFilterAndAllInputObjectsFromGivenConfiguration()
     {
-        $factory     = new Factory();
+        $factory     = $this->createDefaultFactory();
         $inputFilter = $factory->createInputFilter([
             'foo' => [
                 'name'       => 'foo',
@@ -394,7 +394,7 @@ class FactoryTest extends TestCase
 
     public function testFactoryWillCreateInputFilterMatchingInputNameWhenNotSpecified()
     {
-        $factory     = new Factory();
+        $factory     = $this->createDefaultFactory();
         $inputFilter = $factory->createInputFilter([
             ['name' => 'foo']
         ]);
@@ -405,7 +405,7 @@ class FactoryTest extends TestCase
 
     public function testFactoryAllowsPassingValidatorChainsInInputSpec()
     {
-        $factory = new Factory();
+        $factory = $this->createDefaultFactory();
         $chain   = new Validator\ValidatorChain();
         $input   = $factory->createInput([
             'name'       => 'foo',
@@ -418,7 +418,7 @@ class FactoryTest extends TestCase
 
     public function testFactoryAllowsPassingFilterChainsInInputSpec()
     {
-        $factory = new Factory();
+        $factory = $this->createDefaultFactory();
         $chain   = new Filter\FilterChain();
         $input   = $factory->createInput([
             'name'    => 'foo',
@@ -431,7 +431,7 @@ class FactoryTest extends TestCase
 
     public function testFactoryAcceptsCollectionInputFilter()
     {
-        $factory = new Factory();
+        $factory = $this->createDefaultFactory();
 
         /** @var CollectionInputFilter $inputFilter */
         $inputFilter = $factory->createInputFilter([
@@ -449,7 +449,7 @@ class FactoryTest extends TestCase
 
     public function testFactoryWillCreateInputWithErrorMessage()
     {
-        $factory = new Factory();
+        $factory = $this->createDefaultFactory();
         $input   = $factory->createInput([
             'name'          => 'foo',
             'error_message' => 'My custom error message',
@@ -460,7 +460,7 @@ class FactoryTest extends TestCase
     public function testFactoryWillNotGetPrioritySetting()
     {
         //Reminder: Priority at which to enqueue filter; defaults to 1000 (higher executes earlier)
-        $factory = new Factory();
+        $factory = $this->createDefaultFactory();
         $input   = $factory->createInput([
             'name'    => 'foo',
             'filters' => [
@@ -502,7 +502,7 @@ class FactoryTest extends TestCase
 
     public function testConflictNameWithInputFilterType()
     {
-        $factory = new Factory();
+        $factory = $this->createDefaultFactory();
 
         $inputFilter = $factory->createInputFilter(
             [
@@ -532,7 +532,7 @@ class FactoryTest extends TestCase
      */
     public function testCanSetInputErrorMessage()
     {
-        $factory = new Factory();
+        $factory = $this->createDefaultFactory();
         $input   = $factory->createInput([
             'name'          => 'test',
             'type'          => Input::class,
@@ -548,7 +548,7 @@ class FactoryTest extends TestCase
         $serviceManager->setService('ValidatorManager', new Validator\ValidatorPluginManager);
         $serviceManager->setService('FilterManager', new Filter\FilterPluginManager);
         $inputFilterManager->setServiceLocator($serviceManager);
-        $factory = new Factory();
+        $factory = $this->createDefaultFactory();
         $factory->setInputFilterManager($inputFilterManager);
         $this->assertInstanceOf(
             Validator\ValidatorPluginManager::class,
@@ -563,7 +563,7 @@ class FactoryTest extends TestCase
     public function testSetInputFilterManagerWithoutServiceManager()
     {
         $inputFilterManager = new InputFilterPluginManager();
-        $factory = new Factory();
+        $factory = $this->createDefaultFactory();
         $factory->setInputFilterManager($inputFilterManager);
         $this->assertSame($inputFilterManager, $factory->getInputFilterManager());
     }
@@ -582,7 +582,7 @@ class FactoryTest extends TestCase
      */
     public function testSetsBreakChainOnFailure()
     {
-        $factory = new Factory();
+        $factory = $this->createDefaultFactory();
 
         $this->assertTrue($factory->createInput(['break_on_failure' => true])->breakOnFailure());
 
@@ -591,7 +591,7 @@ class FactoryTest extends TestCase
 
     public function testCanCreateInputFilterWithNullInputs()
     {
-        $factory = new Factory();
+        $factory = $this->createDefaultFactory();
 
         $inputFilter = $factory->createInputFilter([
             'foo' => [
@@ -623,7 +623,7 @@ class FactoryTest extends TestCase
             ->method('getInputSpecification')
             ->will($this->returnValue(['name' => 'foo']));
 
-        $factory = new Factory();
+        $factory = $this->createDefaultFactory();
         $input   = $factory->createInput($provider);
 
         $this->assertInstanceOf(InputInterface::class, $input);
@@ -653,7 +653,7 @@ class FactoryTest extends TestCase
                 ],
             ]));
 
-        $factory     = new Factory();
+        $factory     = $this->createDefaultFactory();
         $inputFilter = $factory->createInputFilter($provider);
 
         $this->assertInstanceOf(InputFilterInterface::class, $inputFilter);
@@ -661,7 +661,7 @@ class FactoryTest extends TestCase
 
     public function testSuggestedTypeMayBePluginNameInInputFilterPluginManager()
     {
-        $factory = new Factory();
+        $factory = $this->createDefaultFactory();
         $pluginManager = new InputFilterPluginManager();
         $pluginManager->setService('bar', new Input('bar'));
         $factory->setInputFilterManager($pluginManager);
@@ -679,7 +679,7 @@ class FactoryTest extends TestCase
 
     public function testInputFromPluginManagerMayBeFurtherConfiguredWithSpec()
     {
-        $factory = new Factory();
+        $factory = $this->createDefaultFactory();
         $pluginManager = new InputFilterPluginManager();
         $pluginManager->setService('bar', $barInput = new Input('bar'));
         $this->assertTrue($barInput->isRequired());
@@ -692,5 +692,15 @@ class FactoryTest extends TestCase
 
         $this->assertFalse($input->isRequired());
         $this->assertSame('bar', $input->getName());
+    }
+
+    /**
+     * @return Factory
+     */
+    protected function createDefaultFactory()
+    {
+        $factory = new Factory();
+
+        return $factory;
     }
 }

--- a/test/FactoryTest.php
+++ b/test/FactoryTest.php
@@ -14,9 +14,9 @@ use Zend\Filter;
 use Zend\InputFilter\Factory;
 use Zend\InputFilter\Input;
 use Zend\InputFilter\InputFilter;
-use Zend\Validator;
 use Zend\InputFilter\InputFilterPluginManager;
 use Zend\ServiceManager;
+use Zend\Validator;
 
 /**
  * @covers Zend\InputFilter\Factory

--- a/test/FactoryTest.php
+++ b/test/FactoryTest.php
@@ -18,6 +18,9 @@ use Zend\Validator;
 use Zend\InputFilter\InputFilterPluginManager;
 use Zend\ServiceManager;
 
+/**
+ * @covers Zend\InputFilter\Factory
+ */
 class FactoryTest extends TestCase
 {
     public function testFactoryComposesFilterChainByDefault()

--- a/test/FactoryTest.php
+++ b/test/FactoryTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\InputFilter;
 
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Filter;
 use Zend\InputFilter\CollectionInputFilter;
@@ -612,7 +613,7 @@ class FactoryTest extends TestCase
      */
     public function testCanCreateInputFromProvider()
     {
-        /** @var InputProviderInterface|\PHPUnit_Framework_MockObject_MockObject $provider */
+        /** @var InputProviderInterface|MockObject $provider */
         $provider = $this->getMock(InputProviderInterface::class, ['getInputSpecification']);
 
         $provider
@@ -631,7 +632,7 @@ class FactoryTest extends TestCase
      */
     public function testCanCreateInputFilterFromProvider()
     {
-        /** @var InputFilterProviderInterface|\PHPUnit_Framework_MockObject_MockObject $provider */
+        /** @var InputFilterProviderInterface|MockObject $provider */
         $provider = $this->getMock(
             InputFilterProviderInterface::class,
             ['getInputFilterSpecification']

--- a/test/FactoryTest.php
+++ b/test/FactoryTest.php
@@ -464,11 +464,11 @@ class FactoryTest extends TestCase
             'filters' => [
                 [
                     'name'      => 'string_trim',
-                    'priority'  => \Zend\Filter\FilterChain::DEFAULT_PRIORITY - 1 // 999
+                    'priority'  => Filter\FilterChain::DEFAULT_PRIORITY - 1 // 999
                 ],
                 [
                     'name'      => 'string_to_upper',
-                    'priority'  => \Zend\Filter\FilterChain::DEFAULT_PRIORITY + 1 //1001
+                    'priority'  => Filter\FilterChain::DEFAULT_PRIORITY + 1 //1001
                 ],
                 [
                     'name'      => 'string_to_lower', // default priority 1000

--- a/test/FileInputTest.php
+++ b/test/FileInputTest.php
@@ -20,6 +20,11 @@ use Zend\Validator;
  */
 class FileInputTest extends InputTest
 {
+    public function testIsASubclassOfInput()
+    {
+        $this->assertInstanceOf(Input::class, $this->createDefaultInput());
+    }
+
     public function testValueMayBeInjected()
     {
         $input = $this->createDefaultInput();

--- a/test/FileInputTest.php
+++ b/test/FileInputTest.php
@@ -81,6 +81,32 @@ class FileInputTest extends InputTest
         );
     }
 
+    public function isEmptyProvider()
+    {
+        $data = [/* Description => [$value, $expectedIsEmptyFile] */];
+        $emptyValues = $this->fileInputEmptyValueProvider();
+        $values = $this->fileInputValueProvider();
+
+        foreach ($emptyValues as $valueDescription => $value) {
+            $data[$valueDescription] = [$value, true];
+        }
+        foreach ($values as $valueDescription => $value) {
+            $data[$valueDescription] = [$value, false];
+        }
+
+        return $data;
+    }
+
+    /**
+     * @dataProvider isEmptyProvider
+     */
+    public function testIsEmpty($value, $expectedIsEmptyFile)
+    {
+        $input = $this->createDefaultInput();
+
+        $this->assertEquals($expectedIsEmptyFile, $input->isEmptyFile($value), 'isEmptyFile() value not match');
+    }
+
     public function testRetrievingValueFiltersTheValueOnlyAfterValidating()
     {
         $input = $this->createDefaultInput();
@@ -416,78 +442,47 @@ class FileInputTest extends InputTest
         $this->markTestSkipped('Test is not enabled in FileInputTest');
     }
 
-    public function testIsEmptyFileNotArray()
+    public function fileInputValueProvider()
     {
-        $input = $this->createDefaultInput();
+        $fooErrorOk = [
+            'tmp_name' => 'foo',
+            'error' => \UPLOAD_ERR_OK,
+        ];
+        $barErrorOk = [
+            'tmp_name' => 'bar',
+            'error' => \UPLOAD_ERR_OK,
+        ];
 
-        $rawValue = 'file';
-        $this->assertTrue($input->isEmptyFile($rawValue));
+        return [
+            // Description => [$value]
+            'err_ok' => [$fooErrorOk],
+            '[err_ok]' => [[$fooErrorOk,$barErrorOk]],
+        ];
     }
 
-    public function testIsEmptyFileUploadNoFile()
+    public function fileInputEmptyValueProvider()
     {
-        $input = $this->createDefaultInput();
-
-        $rawValue = [
+        $fileEmptyTmpName = [
             'tmp_name' => '',
             'error' => \UPLOAD_ERR_NO_FILE,
         ];
-        $this->assertTrue($input->isEmptyFile($rawValue));
-    }
-
-    public function testIsEmptyFileOk()
-    {
-        $input = $this->createDefaultInput();
-
-        $rawValue = [
-            'tmp_name' => 'name',
-            'error' => \UPLOAD_ERR_OK,
-        ];
-        $this->assertFalse($input->isEmptyFile($rawValue));
-    }
-
-    public function testIsEmptyMultiFileUploadNoFile()
-    {
-        $input = $this->createDefaultInput();
-
-        $rawValue = [[
+        $fooErrorNoFile = [
             'tmp_name' => 'foo',
-            'error'    => \UPLOAD_ERR_NO_FILE
-        ]];
-        $this->assertTrue($input->isEmptyFile($rawValue));
-    }
-
-    public function testIsEmptyFileMultiFileOk()
-    {
-        $input = $this->createDefaultInput();
-
-        $rawValue = [
-            [
-                'tmp_name' => 'foo',
-                'error'    => \UPLOAD_ERR_OK
-            ],
-            [
-                'tmp_name' => 'bar',
-                'error'    => \UPLOAD_ERR_OK
-            ],
+            'error' => \UPLOAD_ERR_NO_FILE,
         ];
-        $this->assertFalse($input->isEmptyFile($rawValue));
+
+        return [
+            // Description => [$value]
+            'not array' => ['file'],
+            'empty tmp_name' => [$fileEmptyTmpName],
+            'err_no_file' => [$fooErrorNoFile],
+            '[err_no_file]' => [[$fooErrorNoFile]],
+        ];
     }
 
     public function emptyValuesProvider()
     {
-        // Provide empty values specific for file input
-        return [
-            ['file'],
-            [[
-                'tmp_name' => '',
-                'error' => \UPLOAD_ERR_NO_FILE,
-            ]],
-            [[[
-                'tmp_name' => 'foo',
-                'error'    => \UPLOAD_ERR_NO_FILE
-            ]]],
-        ];
+        return $this->fileInputEmptyValueProvider();
     }
 
     /**

--- a/test/FileInputTest.php
+++ b/test/FileInputTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\InputFilter;
 
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use Zend\Filter;
 use Zend\InputFilter\FileInput;
 use Zend\Validator;
@@ -43,6 +44,7 @@ class FileInputTest extends InputTest
         $this->input->setValue($value);
 
         $newValue = ['tmp_name' => 'foo'];
+        /** @var Filter\File\Rename|MockObject $filterMock */
         $filterMock = $this->getMockBuilder(Filter\File\Rename::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -74,6 +76,7 @@ class FileInputTest extends InputTest
         $this->input->setValue($values);
 
         $newValue = ['tmp_name' => 'new'];
+        /** @var Filter\File\Rename|MockObject $filterMock */
         $filterMock = $this->getMockBuilder(Filter\File\Rename::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -139,6 +142,7 @@ class FileInputTest extends InputTest
         $this->input->setValue($badValue);
 
         $filteredValue = ['tmp_name' => 'new'];
+        /** @var Filter\File\Rename|MockObject $filterMock */
         $filterMock = $this->getMockBuilder(Filter\File\Rename::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -269,6 +273,7 @@ class FileInputTest extends InputTest
         $this->assertTrue($this->input->isRequired());
         $this->input->setValue(['tmp_name' => 'bar']);
 
+        /** @var Validator\File\UploadFile|MockObject $uploadMock */
         $uploadMock = $this->getMock(Validator\File\UploadFile::class, ['isValid']);
         $uploadMock->expects($this->exactly(1))
                      ->method('isValid')
@@ -290,6 +295,7 @@ class FileInputTest extends InputTest
         $this->assertTrue($this->input->isRequired());
         $this->input->setValue('');
 
+        /** @var Validator\File\UploadFile|MockObject $uploadMock */
         $uploadMock = $this->getMock(Validator\File\UploadFile::class, ['isValid']);
         $uploadMock->expects($this->exactly(1))
             ->method('isValid')

--- a/test/FileInputTest.php
+++ b/test/FileInputTest.php
@@ -9,8 +9,8 @@
 
 namespace ZendTest\InputFilter;
 
-use Zend\InputFilter\FileInput;
 use Zend\Filter;
+use Zend\InputFilter\FileInput;
 use Zend\Validator;
 
 /**

--- a/test/FileInputTest.php
+++ b/test/FileInputTest.php
@@ -46,6 +46,20 @@ class FileInputTest extends InputTest
         $this->assertEquals($value, $input->getValue(), 'getValue() value not match');
     }
 
+    public function testSetFallbackValue($fallbackValue = null)
+    {
+        $this->markTestSkipped('Input::setFallbackValue is not implemented on FileInput');
+    }
+
+    public function testFallbackValueVsIsValidRules(
+        $fallbackValue = null,
+        $originalValue = null,
+        $isValid = null,
+        $expectedValue = null
+    ) {
+        $this->markTestSkipped('Input::setFallbackValue is not implemented on FileInput');
+    }
+
     /**
      * Specific FileInput::merge extras
      */
@@ -400,11 +414,6 @@ class FileInputTest extends InputTest
     public function testRequiredNotEmptyValidatorNotAddedWhenOneExists()
     {
         $this->markTestSkipped('Test is not enabled in FileInputTest');
-    }
-
-    public function testFallbackValue($fallbackValue = null)
-    {
-        $this->markTestSkipped('Not use fallback value');
     }
 
     public function testIsEmptyFileNotArray()

--- a/test/FileInputTest.php
+++ b/test/FileInputTest.php
@@ -43,7 +43,7 @@ class FileInputTest extends InputTest
         $this->input->setValue($value);
 
         $newValue = ['tmp_name' => 'foo'];
-        $filterMock = $this->getMockBuilder('Zend\Filter\File\Rename')
+        $filterMock = $this->getMockBuilder(Filter\File\Rename::class)
             ->disableOriginalConstructor()
             ->getMock();
         $filterMock->expects($this->any())
@@ -74,7 +74,7 @@ class FileInputTest extends InputTest
         $this->input->setValue($values);
 
         $newValue = ['tmp_name' => 'new'];
-        $filterMock = $this->getMockBuilder('Zend\Filter\File\Rename')
+        $filterMock = $this->getMockBuilder(Filter\File\Rename::class)
             ->disableOriginalConstructor()
             ->getMock();
         $filterMock->expects($this->any())
@@ -139,7 +139,7 @@ class FileInputTest extends InputTest
         $this->input->setValue($badValue);
 
         $filteredValue = ['tmp_name' => 'new'];
-        $filterMock = $this->getMockBuilder('Zend\Filter\File\Rename')
+        $filterMock = $this->getMockBuilder(Filter\File\Rename::class)
             ->disableOriginalConstructor()
             ->getMock();
         $filterMock->expects($this->any())
@@ -247,7 +247,7 @@ class FileInputTest extends InputTest
         $this->assertFalse($this->input->isValid());
         $validators = $validatorChain->getValidators();
         $this->assertEquals(1, count($validators));
-        $this->assertInstanceOf('Zend\Validator\File\UploadFile', $validators[0]['instance']);
+        $this->assertInstanceOf(Validator\File\UploadFile::class, $validators[0]['instance']);
     }
 
     public function testUploadValidatorIsNotAddedWhenIsValidIsCalled()
@@ -269,7 +269,7 @@ class FileInputTest extends InputTest
         $this->assertTrue($this->input->isRequired());
         $this->input->setValue(['tmp_name' => 'bar']);
 
-        $uploadMock = $this->getMock('Zend\Validator\File\UploadFile', ['isValid']);
+        $uploadMock = $this->getMock(Validator\File\UploadFile::class, ['isValid']);
         $uploadMock->expects($this->exactly(1))
                      ->method('isValid')
                      ->will($this->returnValue(true));
@@ -290,7 +290,7 @@ class FileInputTest extends InputTest
         $this->assertTrue($this->input->isRequired());
         $this->input->setValue('');
 
-        $uploadMock = $this->getMock('Zend\Validator\File\UploadFile', ['isValid']);
+        $uploadMock = $this->getMock(Validator\File\UploadFile::class, ['isValid']);
         $uploadMock->expects($this->exactly(1))
             ->method('isValid')
             ->will($this->returnValue(false));
@@ -337,10 +337,10 @@ class FileInputTest extends InputTest
         $this->assertEquals(1, $filterChain->count());
 
         $validators = $validatorChain->getValidators();
-        $this->assertInstanceOf('Zend\Validator\Digits', $validators[0]['instance']);
+        $this->assertInstanceOf(Validator\Digits::class, $validators[0]['instance']);
 
         $filters = $filterChain->getFilters()->toArray();
-        $this->assertInstanceOf('Zend\Filter\StringTrim', $filters[0]);
+        $this->assertInstanceOf(Filter\StringTrim::class, $filters[0]);
     }
 
     public function testFallbackValue($fallbackValue = null)

--- a/test/FileInputTest.php
+++ b/test/FileInputTest.php
@@ -13,6 +13,9 @@ use Zend\InputFilter\FileInput;
 use Zend\Filter;
 use Zend\Validator;
 
+/**
+ * @covers Zend\InputFilter\FileInput
+ */
 class FileInputTest extends InputTest
 {
     public function setUp()

--- a/test/FileInputTest.php
+++ b/test/FileInputTest.php
@@ -19,6 +19,9 @@ use Zend\Validator;
  */
 class FileInputTest extends InputTest
 {
+    /** @var FileInput */
+    protected $input;
+
     public function setUp()
     {
         $this->input = new FileInput('foo');

--- a/test/FileInputTest.php
+++ b/test/FileInputTest.php
@@ -25,6 +25,27 @@ class FileInputTest extends InputTest
         $this->assertInstanceOf(Input::class, $this->createDefaultInput());
     }
 
+    /**
+     * Specific FileInput::merge extras
+     */
+    public function testFileInputMerge()
+    {
+        $source = new FileInput();
+        $source->setAutoPrependUploadValidator(true);
+
+        $target = $this->createDefaultInput();
+        $target->setAutoPrependUploadValidator(false);
+
+        $return = $target->merge($source);
+        $this->assertSame($target, $return, 'merge() must return it self');
+
+        $this->assertEquals(
+            true,
+            $target->getAutoPrependUploadValidator(),
+            'getAutoPrependUploadValidator() value not match'
+        );
+    }
+
     public function testValueMayBeInjected()
     {
         $input = $this->createDefaultInput();
@@ -383,35 +404,6 @@ class FileInputTest extends InputTest
     public function testRequiredNotEmptyValidatorNotAddedWhenOneExists()
     {
         $this->markTestSkipped('Test is not enabled in FileInputTest');
-    }
-
-    public function testMerge()
-    {
-        $value  = ['tmp_name' => 'bar'];
-
-        $input  = $this->createDefaultInput();
-        $input->setAutoPrependUploadValidator(false);
-        $input->setValue($value);
-        $filter = new Filter\StringTrim();
-        $input->getFilterChain()->attach($filter);
-        $validator = new Validator\Digits();
-        $input->getValidatorChain()->attach($validator);
-
-        $input2 = new FileInput('bar');
-        $input2->merge($input);
-        $validatorChain = $input->getValidatorChain();
-        $filterChain    = $input->getFilterChain();
-
-        $this->assertFalse($input2->getAutoPrependUploadValidator());
-        $this->assertEquals($value, $input2->getRawValue());
-        $this->assertEquals(1, $validatorChain->count());
-        $this->assertEquals(1, $filterChain->count());
-
-        $validators = $validatorChain->getValidators();
-        $this->assertInstanceOf(Validator\Digits::class, $validators[0]['instance']);
-
-        $filters = $filterChain->getFilters()->toArray();
-        $this->assertInstanceOf(Filter\StringTrim::class, $filters[0]);
     }
 
     public function testFallbackValue($fallbackValue = null)

--- a/test/FileInputTest.php
+++ b/test/FileInputTest.php
@@ -107,6 +107,18 @@ class FileInputTest extends InputTest
         $this->assertEquals($expectedIsEmptyFile, $input->isEmptyFile($value), 'isEmptyFile() value not match');
     }
 
+    public function testInputContinueIfEmptyAllowEmptyVsIsRequiredVsIsValidRules(
+        $continueIfEmpty = null,
+        $allowEmpty = null,
+        $isRequired = null,
+        $isValid = null,
+        $value = null,
+        $expectedIsValid = null,
+        $expectedMessages = null
+    ) {
+        $this->markTestSkipped('FileInput::isValid is not compatible with Input::isValid');
+    }
+
     public function testRetrievingValueFiltersTheValueOnlyAfterValidating()
     {
         $input = $this->createDefaultInput();

--- a/test/FileInputTest.php
+++ b/test/FileInputTest.php
@@ -459,4 +459,13 @@ class FileInputTest extends InputTest
     {
         $this->markTestSkipped('does not apply to FileInput');
     }
+
+    protected function createDefaultInput()
+    {
+        $input = new FileInput();
+        // Upload validator does not work in CLI test environment, disable
+        $input->setAutoPrependUploadValidator(false);
+
+        return $input;
+    }
 }

--- a/test/FileInputTest.php
+++ b/test/FileInputTest.php
@@ -25,6 +25,27 @@ class FileInputTest extends InputTest
         $this->assertInstanceOf(Input::class, $this->createDefaultInput());
     }
 
+    public function testSetValue($value = null)
+    {
+        $this->markTestSkipped('FileInput::setValue is not compatible with InputInterface::setValue');
+    }
+
+    /**
+     * @dataProvider setValueProvider
+     *
+     * @param mixed $value
+     */
+    public function testFileInputSetValue($value)
+    {
+        $input = $this->createDefaultInput();
+
+        $return = $input->setValue($value);
+        $this->assertSame($input, $return, 'setValue() must return it self');
+
+        $this->assertEquals($value, $input->getRawValue(), 'getRawValue() value not match');
+        $this->assertEquals($value, $input->getValue(), 'getValue() value not match');
+    }
+
     /**
      * Specific FileInput::merge extras
      */
@@ -44,20 +65,6 @@ class FileInputTest extends InputTest
             $target->getAutoPrependUploadValidator(),
             'getAutoPrependUploadValidator() value not match'
         );
-    }
-
-    public function testValueMayBeInjected()
-    {
-        $input = $this->createDefaultInput();
-
-        $value = ['tmp_name' => 'bar'];
-        $input->setValue($value);
-        $this->assertEquals($value, $input->getValue());
-    }
-
-    public function testRetrievingValueFiltersTheValue()
-    {
-        $this->markTestSkipped('Test are not enabled in FileInputTest');
     }
 
     public function testRetrievingValueFiltersTheValueOnlyAfterValidating()
@@ -125,17 +132,6 @@ class FileInputTest extends InputTest
             [$newValue, $newValue, $newValue],
             $input->getValue()
         );
-    }
-
-    public function testCanRetrieveRawValue()
-    {
-        $input = $this->createDefaultInput();
-
-        $value = ['tmp_name' => 'bar'];
-        $input->setValue($value);
-        $filter = new Filter\StringToUpper();
-        $input->getFilterChain()->attach($filter);
-        $this->assertEquals($value, $input->getRawValue());
     }
 
     public function testIsValidReturnsFalseIfValidationChainFails()

--- a/test/FileInputTest.php
+++ b/test/FileInputTest.php
@@ -12,6 +12,7 @@ namespace ZendTest\InputFilter;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use Zend\Filter;
 use Zend\InputFilter\FileInput;
+use Zend\InputFilter\Input;
 use Zend\Validator;
 
 /**
@@ -241,6 +242,44 @@ class FileInputTest extends InputTest
         $this->assertContains('Please enter only digits', $messages);
     }
 
+    public function testWhenRequiredAndAllowEmptyAndNotContinueIfEmptyValidatorsAreNotRun(Input $input = null, $value = null)
+    {
+        $this->markTestIncomplete('Parent test does did not verify ArrayInput object. Pending review');
+    }
+
+    public function testWhenRequiredAndAllowEmptyAndContinueIfEmptyValidatorsAreRun(Input $input = null, $value = null, $assertion = null)
+    {
+        $this->markTestIncomplete('Parent test does did not verify ArrayInput object. Pending review');
+    }
+
+    public function testWhenRequiredAndNotAllowEmptyAndContinueIfEmptyValidatorsAreRun(Input $input = null, $value = null, $assertion = null)
+    {
+        $this->markTestIncomplete('Parent test does did not verify ArrayInput object. Pending review');
+    }
+
+    public function testWhenNotRequiredAndAllowEmptyAndNotContinueIfEmptyValidatorsAreNotRun(Input $input = null, $value = null)
+    {
+        $this->markTestIncomplete('Parent test does did not verify ArrayInput object. Pending review');
+    }
+
+    public function testWhenNotRequiredAndNotAllowEmptyAndNotContinueIfEmptyValidatorsAreNotRun(Input $input = null, $value = null)
+    {
+        $this->markTestIncomplete('Parent test does did not verify ArrayInput object. Pending review');
+    }
+
+    public function testWhenNotRequiredAndAllowEmptyAndContinueIfEmptyValidatorsAreRun(Input $input = null, $value = null, $assertion = null)
+    {
+        $this->markTestIncomplete('Parent test does did not verify ArrayInput object. Pending review');
+    }
+
+    public function testWhenNotRequiredAndNotAllowEmptyAndContinueIfEmptyValidatorsAreRun(
+        Input $input = null,
+        $value = null,
+        $assertion = null
+    ) {
+        $this->markTestIncomplete('Parent test does did not verify ArrayInput object. Pending review');
+    }
+
     public function testAutoPrependUploadValidatorIsOnByDefault()
     {
         $input = new FileInput('foo');
@@ -345,7 +384,7 @@ class FileInputTest extends InputTest
     {
         $value  = ['tmp_name' => 'bar'];
 
-        $input  = new FileInput('foo');
+        $input  = $this->createDefaultInput();
         $input->setAutoPrependUploadValidator(false);
         $input->setValue($value);
         $filter = new Filter\StringTrim();

--- a/test/InputFilterAbstractServiceFactoryTest.php
+++ b/test/InputFilterAbstractServiceFactoryTest.php
@@ -11,10 +11,10 @@ namespace ZendTest\InputFilter;
 
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Filter\FilterPluginManager;
+use Zend\InputFilter\InputFilterAbstractServiceFactory;
 use Zend\InputFilter\InputFilterPluginManager;
 use Zend\ServiceManager\ServiceManager;
 use Zend\Validator\ValidatorPluginManager;
-use Zend\InputFilter\InputFilterAbstractServiceFactory;
 
 /**
  * @covers Zend\InputFilter\InputFilterAbstractServiceFactory

--- a/test/InputFilterAbstractServiceFactoryTest.php
+++ b/test/InputFilterAbstractServiceFactoryTest.php
@@ -23,6 +23,15 @@ use Zend\Validator\ValidatorPluginManager;
  */
 class InputFilterAbstractServiceFactoryTest extends TestCase
 {
+    /** @var ServiceManager */
+    protected $services;
+
+    /** @var InputFilterPluginManager */
+    protected $filters;
+
+    /** @var InputFilterAbstractServiceFactory */
+    protected $factory;
+
     public function setUp()
     {
         $this->services = new ServiceManager();

--- a/test/InputFilterAbstractServiceFactoryTest.php
+++ b/test/InputFilterAbstractServiceFactoryTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\InputFilter;
 
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Filter\FilterPluginManager;
 use Zend\InputFilter\InputFilterAbstractServiceFactory;
@@ -93,6 +94,7 @@ class InputFilterAbstractServiceFactoryTest extends TestCase
         $filters->setService('foo', $filter);
 
         $validators = new ValidatorPluginManager();
+        /** @var ValidatorInterface|MockObject $validator */
         $validator  = $this->getMock(ValidatorInterface::class);
         $validators->setService('foo', $validator);
 
@@ -141,6 +143,7 @@ class InputFilterAbstractServiceFactoryTest extends TestCase
         $filters->setService('foo', $filter);
 
         $validators = new ValidatorPluginManager();
+        /** @var ValidatorInterface|MockObject $validator */
         $validator  = $this->getMock(ValidatorInterface::class);
         $validators->setService('foo', $validator);
 

--- a/test/InputFilterAbstractServiceFactoryTest.php
+++ b/test/InputFilterAbstractServiceFactoryTest.php
@@ -16,6 +16,9 @@ use Zend\ServiceManager\ServiceManager;
 use Zend\Validator\ValidatorPluginManager;
 use Zend\InputFilter\InputFilterAbstractServiceFactory;
 
+/**
+ * @covers Zend\InputFilter\InputFilterAbstractServiceFactory
+ */
 class InputFilterAbstractServiceFactoryTest extends TestCase
 {
     public function setUp()

--- a/test/InputFilterAbstractServiceFactoryTest.php
+++ b/test/InputFilterAbstractServiceFactoryTest.php
@@ -15,6 +15,7 @@ use Zend\Filter\FilterPluginManager;
 use Zend\InputFilter\InputFilterAbstractServiceFactory;
 use Zend\InputFilter\InputFilterInterface;
 use Zend\InputFilter\InputFilterPluginManager;
+use Zend\ServiceManager\AbstractFactoryInterface;
 use Zend\ServiceManager\ServiceManager;
 use Zend\Validator\ValidatorInterface;
 use Zend\Validator\ValidatorPluginManager;
@@ -41,6 +42,11 @@ class InputFilterAbstractServiceFactoryTest extends TestCase
         $this->services->setService('InputFilterManager', $this->filters);
 
         $this->factory = new InputFilterAbstractServiceFactory();
+    }
+
+    public function testImplementsAbstractFactoryInterface()
+    {
+        $this->assertInstanceOf(AbstractFactoryInterface::class, $this->factory);
     }
 
     public function testCannotCreateServiceIfNoConfigServicePresent()

--- a/test/InputFilterAbstractServiceFactoryTest.php
+++ b/test/InputFilterAbstractServiceFactoryTest.php
@@ -12,8 +12,10 @@ namespace ZendTest\InputFilter;
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Filter\FilterPluginManager;
 use Zend\InputFilter\InputFilterAbstractServiceFactory;
+use Zend\InputFilter\InputFilterInterface;
 use Zend\InputFilter\InputFilterPluginManager;
 use Zend\ServiceManager\ServiceManager;
+use Zend\Validator\ValidatorInterface;
 use Zend\Validator\ValidatorPluginManager;
 
 /**
@@ -68,7 +70,7 @@ class InputFilterAbstractServiceFactoryTest extends TestCase
             ],
         ]);
         $filter = $this->factory->createServiceWithName($this->filters, 'filter', 'filter');
-        $this->assertInstanceOf('Zend\InputFilter\InputFilterInterface', $filter);
+        $this->assertInstanceOf(InputFilterInterface::class, $filter);
     }
 
     /**
@@ -82,7 +84,7 @@ class InputFilterAbstractServiceFactoryTest extends TestCase
         $filters->setService('foo', $filter);
 
         $validators = new ValidatorPluginManager();
-        $validator  = $this->getMock('Zend\Validator\ValidatorInterface');
+        $validator  = $this->getMock(ValidatorInterface::class);
         $validators->setService('foo', $validator);
 
         $this->services->setService('FilterManager', $filters);
@@ -130,7 +132,7 @@ class InputFilterAbstractServiceFactoryTest extends TestCase
         $filters->setService('foo', $filter);
 
         $validators = new ValidatorPluginManager();
-        $validator  = $this->getMock('Zend\Validator\ValidatorInterface');
+        $validator  = $this->getMock(ValidatorInterface::class);
         $validators->setService('foo', $validator);
 
         $this->services->setService('FilterManager', $filters);
@@ -151,9 +153,9 @@ class InputFilterAbstractServiceFactoryTest extends TestCase
                 ],
             ],
         ]);
-        $this->services->get('InputFilterManager')->addAbstractFactory('Zend\InputFilter\InputFilterAbstractServiceFactory');
+        $this->services->get('InputFilterManager')->addAbstractFactory(InputFilterAbstractServiceFactory::class);
 
         $inputFilter = $this->services->get('InputFilterManager')->get('foobar');
-        $this->assertInstanceOf('Zend\InputFilter\InputFilterInterface', $inputFilter);
+        $this->assertInstanceOf(InputFilterInterface::class, $inputFilter);
     }
 }

--- a/test/InputFilterAwareInterfaceTestTrait.php
+++ b/test/InputFilterAwareInterfaceTestTrait.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace ZendTest\InputFilter;
+
+use PHPUnit_Framework_Assert as Assert;
+use Zend\InputFilter\InputFilterAwareInterface;
+
+/**
+ * Compliance test methods for `Zend\InputFilter\InputFilterAwareInterface` implementations.
+ */
+trait InputFilterAwareInterfaceTestTrait
+{
+    public function testImplementsInputFilterAwareInterface()
+    {
+        Assert::assertInstanceOf(InputFilterAwareInterface::class, $this->createDefaultInputFilterAware());
+    }
+
+    /**
+     * @return InputFilterAwareInterface
+     */
+    abstract protected function createDefaultInputFilterAware();
+}

--- a/test/InputFilterAwareInterfaceTestTrait.php
+++ b/test/InputFilterAwareInterfaceTestTrait.php
@@ -2,17 +2,35 @@
 
 namespace ZendTest\InputFilter;
 
+use Maks3w\PhpUnitMethodsTrait\Framework\TestCaseTrait;
 use PHPUnit_Framework_Assert as Assert;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use Zend\InputFilter\InputFilterAwareInterface;
+use Zend\InputFilter\InputFilterInterface;
 
 /**
  * Compliance test methods for `Zend\InputFilter\InputFilterAwareInterface` implementations.
  */
 trait InputFilterAwareInterfaceTestTrait
 {
+    use TestCaseTrait;
+
     public function testImplementsInputFilterAwareInterface()
     {
         Assert::assertInstanceOf(InputFilterAwareInterface::class, $this->createDefaultInputFilterAware());
+    }
+
+    public function testSetInputFilter()
+    {
+        $object = $this->createDefaultInputFilterAware();
+
+        /** @var InputFilterInterface|MockObject $inputFilter */
+        $inputFilter = $this->getMock(InputFilterInterface::class);
+
+        $object->setInputFilter($inputFilter);
+
+        Assert::assertAttributeSame($inputFilter, 'inputFilter', $object, '$inputFilter value not match');
+        Assert::assertSame($inputFilter, $object->getInputFilter(), 'getInputFilter value not match');
     }
 
     /**

--- a/test/InputFilterAwareTraitTest.php
+++ b/test/InputFilterAwareTraitTest.php
@@ -10,7 +10,6 @@
 namespace ZendTest\InputFilter;
 
 use PHPUnit_Framework_TestCase as TestCase;
-use Zend\InputFilter\InputFilter;
 use Zend\InputFilter\InputFilterAwareTrait;
 
 /**
@@ -19,29 +18,17 @@ use Zend\InputFilter\InputFilterAwareTrait;
  */
 class InputFilterAwareTraitTest extends TestCase
 {
-    public function testSetInputFilter()
+    use InputFilterAwareInterfaceTestTrait;
+
+    public function testImplementsInputFilterAwareInterface()
     {
-        $object = $this->getObjectForTrait(InputFilterAwareTrait::class);
-
-        $this->assertAttributeEquals(null, 'inputFilter', $object);
-
-        $inputFilter = new InputFilter;
-
-        $object->setInputFilter($inputFilter);
-
-        $this->assertAttributeEquals($inputFilter, 'inputFilter', $object);
+        $this->markTestSkipped("Traits don't implement interfaces");
     }
 
-    public function testGetInputFilter()
+    protected function createDefaultInputFilterAware()
     {
-        $object = $this->getObjectForTrait(InputFilterAwareTrait::class);
+        $trait = $this->getObjectForTrait(InputFilterAwareTrait::class);
 
-        $this->assertNull($object->getInputFilter());
-
-        $inputFilter = new InputFilter;
-
-        $object->setInputFilter($inputFilter);
-
-        $this->assertEquals($inputFilter, $object->getInputFilter());
+        return $trait;
     }
 }

--- a/test/InputFilterAwareTraitTest.php
+++ b/test/InputFilterAwareTraitTest.php
@@ -14,6 +14,7 @@ use Zend\InputFilter\InputFilter;
 
 /**
  * @requires PHP 5.4
+ * @covers Zend\InputFilter\InputFilterAwareTrait
  */
 class InputFilterAwareTraitTest extends TestCase
 {

--- a/test/InputFilterAwareTraitTest.php
+++ b/test/InputFilterAwareTraitTest.php
@@ -11,6 +11,7 @@ namespace ZendTest\InputFilter;
 
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\InputFilter\InputFilter;
+use Zend\InputFilter\InputFilterAwareTrait;
 
 /**
  * @requires PHP 5.4
@@ -20,7 +21,7 @@ class InputFilterAwareTraitTest extends TestCase
 {
     public function testSetInputFilter()
     {
-        $object = $this->getObjectForTrait('\Zend\InputFilter\InputFilterAwareTrait');
+        $object = $this->getObjectForTrait(InputFilterAwareTrait::class);
 
         $this->assertAttributeEquals(null, 'inputFilter', $object);
 
@@ -33,7 +34,7 @@ class InputFilterAwareTraitTest extends TestCase
 
     public function testGetInputFilter()
     {
-        $object = $this->getObjectForTrait('\Zend\InputFilter\InputFilterAwareTrait');
+        $object = $this->getObjectForTrait(InputFilterAwareTrait::class);
 
         $this->assertNull($object->getInputFilter());
 

--- a/test/InputFilterInterfaceTestTrait.php
+++ b/test/InputFilterInterfaceTestTrait.php
@@ -2,21 +2,157 @@
 
 namespace ZendTest\InputFilter;
 
+use Maks3w\PhpUnitMethodsTrait\Framework\TestCaseTrait;
 use PHPUnit_Framework_Assert as Assert;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use Zend\InputFilter\Input;
 use Zend\InputFilter\InputFilterInterface;
+use Zend\InputFilter\InputInterface;
 
 /**
  * Compliance test methods for `Zend\InputFilter\InputFilterInterface` implementations.
  */
 trait InputFilterInterfaceTestTrait
 {
+    use TestCaseTrait;
+
     public function testImplementsInputFilterInterface()
     {
         Assert::assertInstanceOf(InputFilterInterface::class, $this->createDefaultInputFilter());
     }
 
     /**
+     * Verify the state of the input filter is the desired after change it using the method `add()`
+     *
+     * @dataProvider addMethodArgumentsProvider
+     *
+     * @param mixed $input
+     * @param string $name
+     * @param string $expectedInputName
+     * @param mixed $expectedInput
+     */
+    public function testAddHasGet($input, $name, $expectedInputName, $expectedInput)
+    {
+        $inputFilter = $this->createDefaultInputFilter();
+        Assert::assertFalse(
+            $inputFilter->has($expectedInputName),
+            "InputFilter shouldn't have an input with the name $expectedInputName yet"
+        );
+        $currentNumberOfFilters = count($inputFilter);
+
+        $return = $inputFilter->add($input, $name);
+        Assert::assertSame($inputFilter, $return, "InputFilter::add() must return it self");
+
+        // **Check input collection state**
+        Assert::assertTrue($inputFilter->has($expectedInputName), "There is no input with name $expectedInputName");
+        Assert::assertCount($currentNumberOfFilters + 1, $inputFilter, 'Number of filters must be increased by 1');
+
+        $returnInput = $inputFilter->get($expectedInputName);
+        Assert::assertEquals($expectedInput, $returnInput, 'InputFilter::get() does not match the expected input');
+    }
+
+    public function testAddingInputWithNameDoesNotInjectNameInInput()
+    {
+        $inputFilter = $this->createDefaultInputFilter();
+
+        $foo = new Input('foo');
+        $inputFilter->add($foo, 'bar');
+
+        $test = $inputFilter->get('bar');
+        Assert::assertSame($foo, $test, 'InputFilter::get() does not match the input added');
+        Assert::assertEquals('foo', $foo->getName(), 'Input name should not change');
+    }
+
+    /**
+     * Verify the state of the input filter is the desired after change it using the method `add()` and `remove()`
+     *
+     * @dataProvider addMethodArgumentsProvider
+     *
+     * @param mixed $input
+     * @param string $name
+     * @param string $expectedInputName
+     */
+    public function testAddRemove($input, $name, $expectedInputName)
+    {
+        $inputFilter = $this->createDefaultInputFilter();
+
+        $inputFilter->add($input, $name);
+        $currentNumberOfFilters = count($inputFilter);
+
+        $return = $inputFilter->remove($expectedInputName);
+        Assert::assertSame($inputFilter, $return, 'InputFilter::remove() must return it self');
+
+        Assert::assertFalse($inputFilter->has($expectedInputName), "There is no input with name $expectedInputName");
+        Assert::assertCount($currentNumberOfFilters - 1, $inputFilter, 'Number of filters must be decreased by 1');
+    }
+
+    public function addMethodArgumentsProvider()
+    {
+        // Description => [$input argument, $name argument, $expectedName, $expectedInput]
+        $tests = [];
+        $inputTypes = $this->inputProvider();
+
+        // Default $name argument (null)
+        foreach ($inputTypes as $inputTypeDescription => $inputTypeData) {
+            $description = $inputTypeDescription . ' - null';
+
+            $tests[$description] = [$inputTypeData[0], null, $inputTypeData[1], $inputTypeData[2]];
+        }
+
+        // Custom $name argument
+        foreach ($inputTypes as $inputTypeDescription => $inputTypeData) {
+            static $customInputName = 'custom_name';
+
+            $description = $inputTypeDescription . ' - ' . $customInputName;
+
+            $tests[$description] = [$inputTypeData[0], $customInputName, $customInputName, $inputTypeData[2]];
+        }
+
+        return $tests;
+    }
+
+    public function inputProvider()
+    {
+        $input = $this->createInputInterfaceMock('inputFoo');
+        $inputFilter = $this->createInputFilterInterfaceMock();
+
+        return [
+            // Description => [input, name, expected name, $expectedReturnInput]
+            'InputInterface' => [$input, 'inputFoo', $input],
+            'InputFilterInterface' => [$inputFilter, null, $inputFilter],
+        ];
+    }
+
+    /**
      * @return InputFilterInterface
      */
     abstract protected function createDefaultInputFilter();
+
+    /**
+     * @return MockObject|InputFilterInterface
+     */
+    protected function createInputFilterInterfaceMock()
+    {
+        /** @var InputFilterInterface|MockObject $inputFilter */
+        $inputFilter = $this->getMock(InputFilterInterface::class);
+
+        return $inputFilter;
+    }
+
+    /**
+     * @param null|string $name
+     *
+     * @return MockObject|InputInterface
+     */
+    protected function createInputInterfaceMock($name = null)
+    {
+        /** @var InputInterface|MockObject $input */
+        $input = $this->getMock(InputInterface::class);
+
+        $input->method('getName')
+            ->willReturn($name)
+        ;
+
+        return $input;
+    }
 }

--- a/test/InputFilterInterfaceTestTrait.php
+++ b/test/InputFilterInterfaceTestTrait.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace ZendTest\InputFilter;
+
+use PHPUnit_Framework_Assert as Assert;
+use Zend\InputFilter\InputFilterInterface;
+
+/**
+ * Compliance test methods for `Zend\InputFilter\InputFilterInterface` implementations.
+ */
+trait InputFilterInterfaceTestTrait
+{
+    public function testImplementsInputFilterInterface()
+    {
+        Assert::assertInstanceOf(InputFilterInterface::class, $this->createDefaultInputFilter());
+    }
+
+    /**
+     * @return InputFilterInterface
+     */
+    abstract protected function createDefaultInputFilter();
+}

--- a/test/InputFilterManagerTest.php
+++ b/test/InputFilterManagerTest.php
@@ -13,6 +13,7 @@ use Zend\InputFilter\InputFilterPluginManager;
 
 /**
  * @group Zend_Stdlib
+ * @covers Zend\InputFilter\InputFilterPluginManager
  */
 class InputFilterManagerTest extends \PHPUnit_Framework_TestCase
 {

--- a/test/InputFilterPluginManagerTest.php
+++ b/test/InputFilterPluginManagerTest.php
@@ -38,7 +38,10 @@ class InputFilterPluginManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testRegisteringInvalidElementRaisesException()
     {
-        $this->setExpectedException(RuntimeException::class);
+        $this->setExpectedException(
+            RuntimeException::class,
+            'must implement Zend\InputFilter\InputFilterInterface or Zend\InputFilter\InputInterface'
+        );
         $this->manager->setService('test', $this);
     }
 

--- a/test/InputFilterPluginManagerTest.php
+++ b/test/InputFilterPluginManagerTest.php
@@ -15,7 +15,7 @@ use Zend\InputFilter\InputFilterPluginManager;
  * @group Zend_Stdlib
  * @covers Zend\InputFilter\InputFilterPluginManager
  */
-class InputFilterManagerTest extends \PHPUnit_Framework_TestCase
+class InputFilterPluginManagerTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var InputFilterPluginManager

--- a/test/InputFilterPluginManagerTest.php
+++ b/test/InputFilterPluginManagerTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\InputFilter;
 
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use Zend\InputFilter\Exception\RuntimeException;
 use Zend\InputFilter\InputFilterInterface;
 use Zend\InputFilter\InputFilterPluginManager;
@@ -47,6 +48,7 @@ class InputFilterPluginManagerTest extends \PHPUnit_Framework_TestCase
      */
     public function testAllowLoadingInstancesOfInputFilterInterface()
     {
+        /** @var InputFilterInterface|MockObject $inputFilter */
         $inputFilter = $this->getMock(InputFilterInterface::class);
 
         $this->assertNull($this->manager->validatePlugin($inputFilter));
@@ -57,6 +59,7 @@ class InputFilterPluginManagerTest extends \PHPUnit_Framework_TestCase
      */
     public function testAllowLoadingInstancesOfInputInterface()
     {
+        /** @var InputInterface|MockObject $input */
         $input = $this->getMock(InputInterface::class);
 
         $this->assertNull($this->manager->validatePlugin($input));

--- a/test/InputFilterPluginManagerTest.php
+++ b/test/InputFilterPluginManagerTest.php
@@ -12,7 +12,6 @@ namespace ZendTest\InputFilter;
 use Zend\InputFilter\InputFilterPluginManager;
 
 /**
- * @group Zend_Stdlib
  * @covers Zend\InputFilter\InputFilterPluginManager
  */
 class InputFilterPluginManagerTest extends \PHPUnit_Framework_TestCase

--- a/test/InputFilterPluginManagerTest.php
+++ b/test/InputFilterPluginManagerTest.php
@@ -45,7 +45,10 @@ class InputFilterPluginManagerTest extends \PHPUnit_Framework_TestCase
     public function testLoadingInvalidElementRaisesException()
     {
         $this->manager->setInvokableClass('test', get_class($this));
-        $this->setExpectedException(RuntimeException::class);
+        $this->setExpectedException(
+            RuntimeException::class,
+            'must implement Zend\InputFilter\InputFilterInterface or Zend\InputFilter\InputInterface'
+        );
         $this->manager->get('test');
     }
 

--- a/test/InputFilterPluginManagerTest.php
+++ b/test/InputFilterPluginManagerTest.php
@@ -9,7 +9,10 @@
 
 namespace ZendTest\InputFilter;
 
+use Zend\InputFilter\Exception\RuntimeException;
+use Zend\InputFilter\InputFilterInterface;
 use Zend\InputFilter\InputFilterPluginManager;
+use Zend\InputFilter\InputInterface;
 
 /**
  * @covers Zend\InputFilter\InputFilterPluginManager
@@ -28,14 +31,14 @@ class InputFilterPluginManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testRegisteringInvalidElementRaisesException()
     {
-        $this->setExpectedException('Zend\InputFilter\Exception\RuntimeException');
+        $this->setExpectedException(RuntimeException::class);
         $this->manager->setService('test', $this);
     }
 
     public function testLoadingInvalidElementRaisesException()
     {
         $this->manager->setInvokableClass('test', get_class($this));
-        $this->setExpectedException('Zend\InputFilter\Exception\RuntimeException');
+        $this->setExpectedException(RuntimeException::class);
         $this->manager->get('test');
     }
 
@@ -44,7 +47,7 @@ class InputFilterPluginManagerTest extends \PHPUnit_Framework_TestCase
      */
     public function testAllowLoadingInstancesOfInputFilterInterface()
     {
-        $inputFilter = $this->getMock('Zend\InputFilter\InputFilterInterface');
+        $inputFilter = $this->getMock(InputFilterInterface::class);
 
         $this->assertNull($this->manager->validatePlugin($inputFilter));
     }
@@ -54,7 +57,7 @@ class InputFilterPluginManagerTest extends \PHPUnit_Framework_TestCase
      */
     public function testAllowLoadingInstancesOfInputInterface()
     {
-        $input = $this->getMock('Zend\InputFilter\InputInterface');
+        $input = $this->getMock(InputInterface::class);
 
         $this->assertNull($this->manager->validatePlugin($input));
     }

--- a/test/InputFilterPluginManagerTest.php
+++ b/test/InputFilterPluginManagerTest.php
@@ -10,11 +10,17 @@
 namespace ZendTest\InputFilter;
 
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use Zend\Filter\FilterPluginManager;
+use Zend\InputFilter\CollectionInputFilter;
 use Zend\InputFilter\Exception\RuntimeException;
+use Zend\InputFilter\InputFilter;
 use Zend\InputFilter\InputFilterInterface;
 use Zend\InputFilter\InputFilterPluginManager;
 use Zend\InputFilter\InputInterface;
 use Zend\ServiceManager\AbstractPluginManager;
+use Zend\ServiceManager\ServiceLocatorInterface;
+use Zend\Stdlib\InitializableInterface;
+use Zend\Validator\ValidatorPluginManager;
 
 /**
  * @covers Zend\InputFilter\InputFilterPluginManager
@@ -36,6 +42,11 @@ class InputFilterPluginManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(AbstractPluginManager::class, $this->manager);
     }
 
+    public function testIsNotSharedByDefault()
+    {
+        $this->assertFalse($this->manager->shareByDefault());
+    }
+
     public function testRegisteringInvalidElementRaisesException()
     {
         $this->setExpectedException(
@@ -55,25 +66,152 @@ class InputFilterPluginManagerTest extends \PHPUnit_Framework_TestCase
         $this->manager->get('test');
     }
 
+    public function defaultInvokableClassesProvider()
+    {
+        return [
+            // Description => [$alias, $expectedInstance]
+            'inputfilter' => ['inputfilter', InputFilter::class],
+            'collection' => ['collection', CollectionInputFilter::class],
+        ];
+    }
+
     /**
-     * @covers Zend\InputFilter\InputFilterPluginManager::validatePlugin
+     * @dataProvider defaultInvokableClassesProvider
      */
-    public function testAllowLoadingInstancesOfInputFilterInterface()
+    public function testDefaultInvokableClasses($alias, $expectedInstance)
+    {
+        $service = $this->manager->get($alias);
+
+        $this->assertInstanceOf($expectedInstance, $service, 'get() return type not match');
+    }
+
+    public function testInputFilterInvokableClassSMDependenciesArePopulatedWithoutServiceLocator()
+    {
+        $this->assertNull($this->manager->getServiceLocator(), 'Plugin manager is expected to no have a service locator');
+
+        /** @var InputFilter $service */
+        $service = $this->manager->get('inputfilter');
+
+        $factory = $service->getFactory();
+        $this->assertSame(
+            $this->manager,
+            $factory->getInputFilterManager(),
+            'Factory::getInputFilterManager() is not populated with the expected plugin manager'
+        );
+    }
+
+    public function testInputFilterInvokableClassSMDependenciesArePopulatedWithServiceLocator()
+    {
+        $filterManager = $this->getMock(FilterPluginManager::class);
+        $validatorManager = $this->getMock(ValidatorPluginManager::class);
+
+        $serviceLocator = $this->createServiceLocatorInterfaceMock();
+        $serviceLocator->method('get')
+            ->willReturnMap(
+                [
+                    ['FilterManager', $filterManager],
+                    ['ValidatorManager', $validatorManager],
+                ]
+            )
+        ;
+
+        $this->manager->setServiceLocator($serviceLocator);
+        $this->assertSame($serviceLocator, $this->manager->getServiceLocator(), 'getServiceLocator() value not match');
+
+        /** @var InputFilter $service */
+        $service = $this->manager->get('inputfilter');
+
+        $factory = $service->getFactory();
+        $this->assertSame(
+            $this->manager,
+            $factory->getInputFilterManager(),
+            'Factory::getInputFilterManager() is not populated with the expected plugin manager'
+        );
+
+        $defaultFilterChain = $factory->getDefaultFilterChain();
+        $this->assertSame(
+            $filterManager,
+            $defaultFilterChain->getPluginManager(),
+            'Factory::getDefaultFilterChain() is not populated with the expected plugin manager'
+        );
+
+        $defaultValidatorChain = $factory->getDefaultValidatorChain();
+        $this->assertSame(
+            $validatorManager,
+            $defaultValidatorChain->getPluginManager(),
+            'Factory::getDefaultValidatorChain() is not populated with the expected plugin manager'
+        );
+    }
+
+    public function serviceProvider()
+    {
+        $inputFilterInterfaceMock = $this->createInputFilterInterfaceMock();
+        $inputInterfaceMock = $this->createInputInterfaceMock();
+
+        // @formatter:off
+        return [
+            // Description => [$serviceName, $service, $instanceOf]
+            'InputFilterInterface' => ['inputFilterInterfaceService', $inputFilterInterfaceMock, InputFilterInterface::class],
+            'InputInterface' => ['inputInterfaceService', $inputInterfaceMock, InputInterface::class],
+        ];
+        // @formatter:on
+    }
+
+    /**
+     * @dataProvider serviceProvider
+     */
+    public function testGet($serviceName, $service)
+    {
+        $this->manager->setService($serviceName, $service);
+
+        $this->assertSame($service, $this->manager->get($serviceName), 'get() value not match');
+    }
+
+    /**
+     * @dataProvider serviceProvider
+     */
+    public function testServicesAreInitiatedIfImplementsInitializableInterface($serviceName, $service, $instanceOf)
+    {
+        $initializableProphecy = $this->prophesize($instanceOf)->willImplement(InitializableInterface::class);
+        $service = $initializableProphecy->reveal();
+
+        $this->manager->setService($serviceName, $service);
+        $this->assertSame($service, $this->manager->get($serviceName), 'get() value not match');
+
+        /** @noinspection PhpUndefinedMethodInspection */
+        $initializableProphecy->init()->shouldBeCalled();
+    }
+
+    /**
+     * @return MockObject|InputFilterInterface
+     */
+    protected function createInputFilterInterfaceMock()
     {
         /** @var InputFilterInterface|MockObject $inputFilter */
         $inputFilter = $this->getMock(InputFilterInterface::class);
 
-        $this->assertNull($this->manager->validatePlugin($inputFilter));
+        return $inputFilter;
     }
 
     /**
-     * @covers Zend\InputFilter\InputFilterPluginManager::validatePlugin
+     * @return MockObject|InputInterface
      */
-    public function testAllowLoadingInstancesOfInputInterface()
+    protected function createInputInterfaceMock()
     {
         /** @var InputInterface|MockObject $input */
         $input = $this->getMock(InputInterface::class);
 
-        $this->assertNull($this->manager->validatePlugin($input));
+        return $input;
+    }
+
+    /**
+     * @return MockObject|ServiceLocatorInterface
+     */
+    protected function createServiceLocatorInterfaceMock()
+    {
+        /** @var ServiceLocatorInterface|MockObject $serviceLocator */
+        $serviceLocator = $this->getMock(ServiceLocatorInterface::class);
+
+        return $serviceLocator;
     }
 }

--- a/test/InputFilterPluginManagerTest.php
+++ b/test/InputFilterPluginManagerTest.php
@@ -14,6 +14,7 @@ use Zend\InputFilter\Exception\RuntimeException;
 use Zend\InputFilter\InputFilterInterface;
 use Zend\InputFilter\InputFilterPluginManager;
 use Zend\InputFilter\InputInterface;
+use Zend\ServiceManager\AbstractPluginManager;
 
 /**
  * @covers Zend\InputFilter\InputFilterPluginManager
@@ -28,6 +29,11 @@ class InputFilterPluginManagerTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->manager = new InputFilterPluginManager();
+    }
+
+    public function testIsASubclassOfAbstractPluginManager()
+    {
+        $this->assertInstanceOf(AbstractPluginManager::class, $this->manager);
     }
 
     public function testRegisteringInvalidElementRaisesException()

--- a/test/InputFilterProviderInterfaceTestTrait.php
+++ b/test/InputFilterProviderInterfaceTestTrait.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace ZendTest\InputFilter;
+
+use PHPUnit_Framework_Assert as Assert;
+use Zend\InputFilter\InputFilterProviderInterface;
+
+/**
+ * Compliance test methods for `Zend\InputFilter\InputFilterProviderInterface` implementations.
+ */
+trait InputFilterProviderInterfaceTestTrait
+{
+    public function testImplementsInputFilterProviderInterface()
+    {
+        Assert::assertInstanceOf(InputFilterProviderInterface::class, $this->createDefaultInputFilterProvider());
+    }
+
+    /**
+     * @return InputFilterProviderInterface
+     */
+    abstract protected function createDefaultInputFilterProvider();
+}

--- a/test/InputFilterTest.php
+++ b/test/InputFilterTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\InputFilter;
 
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Filter;
 use Zend\InputFilter\CollectionInputFilter;
@@ -110,6 +111,7 @@ class InputFilterTest extends TestCase
     {
         $context = new \stdClass();
 
+        /** @var InputInterface|MockObject $input */
         $input = $this->getMock(InputInterface::class);
         $input->expects($this->once())->method('isValid')->with($context)->will($this->returnValue(true));
         $input->expects($this->any())->method('getRawValue')->will($this->returnValue('Mwop'));

--- a/test/InputFilterTest.php
+++ b/test/InputFilterTest.php
@@ -11,7 +11,6 @@ namespace ZendTest\InputFilter;
 
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use PHPUnit_Framework_TestCase as TestCase;
-use Zend\Filter;
 use Zend\InputFilter\CollectionInputFilter;
 use Zend\InputFilter\Factory;
 use Zend\InputFilter\Input;

--- a/test/InputFilterTest.php
+++ b/test/InputFilterTest.php
@@ -22,6 +22,10 @@ use Zend\InputFilter\InputInterface;
  */
 class InputFilterTest extends TestCase
 {
+    use InputFilterInterfaceTestTrait;
+    use ReplaceableInputInterfaceTestTrait;
+    use UnknownInputsCapableInterfaceTestTrait;
+
     /**
      * @var InputFilter
      */
@@ -119,5 +123,22 @@ class InputFilterTest extends TestCase
         $this->filter->setData(['username' => 'Mwop']);
 
         $this->filter->isValid($context);
+    }
+
+    protected function createDefaultInputFilter()
+    {
+        $inputFilter = new InputFilter();
+
+        return $inputFilter;
+    }
+
+    protected function createDefaultReplaceableInput()
+    {
+        return $this->createDefaultInputFilter();
+    }
+
+    protected function createDefaultUnknownInputsCapable()
+    {
+        return $this->createDefaultInputFilter();
     }
 }

--- a/test/InputFilterTest.php
+++ b/test/InputFilterTest.php
@@ -10,7 +10,6 @@
 namespace ZendTest\InputFilter;
 
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
-use PHPUnit_Framework_TestCase as TestCase;
 use Zend\InputFilter\CollectionInputFilter;
 use Zend\InputFilter\Factory;
 use Zend\InputFilter\Input;
@@ -20,12 +19,8 @@ use Zend\InputFilter\InputInterface;
 /**
  * @covers Zend\InputFilter\InputFilter
  */
-class InputFilterTest extends TestCase
+class InputFilterTest extends BaseInputFilterTest
 {
-    use InputFilterInterfaceTestTrait;
-    use ReplaceableInputInterfaceTestTrait;
-    use UnknownInputsCapableInterfaceTestTrait;
-
     public function testLazilyComposesAFactoryByDefault()
     {
         $inputFilter = $this->createDefaultInputFilter();
@@ -132,15 +127,5 @@ class InputFilterTest extends TestCase
         $inputFilter = new InputFilter();
 
         return $inputFilter;
-    }
-
-    protected function createDefaultReplaceableInput()
-    {
-        return $this->createDefaultInputFilter();
-    }
-
-    protected function createDefaultUnknownInputsCapable()
-    {
-        return $this->createDefaultInputFilter();
     }
 }

--- a/test/InputFilterTest.php
+++ b/test/InputFilterTest.php
@@ -10,6 +10,7 @@
 namespace ZendTest\InputFilter;
 
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use Zend\InputFilter\BaseInputFilter;
 use Zend\InputFilter\CollectionInputFilter;
 use Zend\InputFilter\Factory;
 use Zend\InputFilter\Input;
@@ -21,6 +22,11 @@ use Zend\InputFilter\InputInterface;
  */
 class InputFilterTest extends BaseInputFilterTest
 {
+    public function testIsASubclassOfBaseInputFilter()
+    {
+        $this->assertInstanceOf(BaseInputFilter::class, $this->createDefaultInputFilter());
+    }
+
     public function testLazilyComposesAFactoryByDefault()
     {
         $inputFilter = $this->createDefaultInputFilter();

--- a/test/InputFilterTest.php
+++ b/test/InputFilterTest.php
@@ -15,6 +15,7 @@ use Zend\InputFilter\CollectionInputFilter;
 use Zend\InputFilter\Factory;
 use Zend\InputFilter\Input;
 use Zend\InputFilter\InputFilter;
+use Zend\InputFilter\InputInterface;
 
 /**
  * @covers Zend\InputFilter\InputFilter
@@ -34,7 +35,7 @@ class InputFilterTest extends TestCase
     public function testLazilyComposesAFactoryByDefault()
     {
         $factory = $this->filter->getFactory();
-        $this->assertInstanceOf('Zend\InputFilter\Factory', $factory);
+        $this->assertInstanceOf(Factory::class, $factory);
     }
 
     public function testCanComposeAFactory()
@@ -51,7 +52,7 @@ class InputFilterTest extends TestCase
         ]);
         $this->assertTrue($this->filter->has('foo'));
         $foo = $this->filter->get('foo');
-        $this->assertInstanceOf('Zend\InputFilter\InputInterface', $foo);
+        $this->assertInstanceOf(InputInterface::class, $foo);
     }
 
     /**
@@ -109,7 +110,7 @@ class InputFilterTest extends TestCase
     {
         $context = new \stdClass();
 
-        $input = $this->getMock('Zend\InputFilter\InputInterface');
+        $input = $this->getMock(InputInterface::class);
         $input->expects($this->once())->method('isValid')->with($context)->will($this->returnValue(true));
         $input->expects($this->any())->method('getRawValue')->will($this->returnValue('Mwop'));
 

--- a/test/InputFilterTest.php
+++ b/test/InputFilterTest.php
@@ -64,7 +64,7 @@ class InputFilterTest extends TestCase
     {
         $inputFilter = $this->createDefaultInputFilter();
 
-        $nestedInputFilter = new InputFilter();
+        $nestedInputFilter = $this->createDefaultInputFilter();
         $nestedInputFilter->add(new Input(), 'name');
 
         $inputFilter->add($nestedInputFilter, 'people');
@@ -88,7 +88,7 @@ class InputFilterTest extends TestCase
     {
         $inputFilter = $this->createDefaultInputFilter();
 
-        $nestedInputFilter = new InputFilter();
+        $nestedInputFilter = $this->createDefaultInputFilter();
         $nestedInputFilter->add(new Input(), 'name');
 
         $collection = new CollectionInputFilter();

--- a/test/InputFilterTest.php
+++ b/test/InputFilterTest.php
@@ -16,6 +16,9 @@ use Zend\InputFilter\Factory;
 use Zend\InputFilter\Input;
 use Zend\InputFilter\InputFilter;
 
+/**
+ * @covers Zend\InputFilter\InputFilter
+ */
 class InputFilterTest extends TestCase
 {
     /**

--- a/test/InputInterfaceTestTrait.php
+++ b/test/InputInterfaceTestTrait.php
@@ -2,21 +2,102 @@
 
 namespace ZendTest\InputFilter;
 
+use Maks3w\PhpUnitMethodsTrait\Framework\TestCaseTrait;
 use PHPUnit_Framework_Assert as Assert;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Filter\FilterChain;
 use Zend\InputFilter\InputInterface;
+use Zend\Validator\ValidatorChain;
 
 /**
  * Compliance test methods for `Zend\InputFilter\InputInterface` implementations.
  */
 trait InputInterfaceTestTrait
 {
+    use TestCaseTrait;
+
     public function testImplementsInputInterface()
     {
         Assert::assertInstanceOf(InputInterface::class, $this->createDefaultInput());
+    }
+
+    public function testMerge()
+    {
+        $source = $this->createInputInterfaceMock();
+        $source->method('getName')->willReturn('bazInput');
+        $source->method('getErrorMessage')->willReturn('bazErrorMessage');
+        $source->method('breakOnFailure')->willReturn(true);
+        $source->method('isRequired')->willReturn(true);
+        $source->method('getRawValue')->willReturn('bazRawValue');
+        $source->method('getFilterChain')->willReturn($this->createFilterChainMock());
+        $source->method('getValidatorChain')->willReturn($this->createValidatorChainMock());
+
+        $targetFilterChain = $this->createFilterChainMock();
+        $targetFilterChain->expects(TestCase::once())
+            ->method('merge')
+            ->with($source->getFilterChain())
+        ;
+
+        $targetValidatorChain = $this->createValidatorChainMock();
+        $targetValidatorChain->expects(TestCase::once())
+            ->method('merge')
+            ->with($source->getValidatorChain())
+        ;
+
+        $target = $this->createDefaultInput();
+        $target->setName('fooInput');
+        $target->setErrorMessage('fooErrorMessage');
+        $target->setBreakOnFailure(false);
+        $target->setRequired(false);
+        $target->setFilterChain($targetFilterChain);
+        $target->setValidatorChain($targetValidatorChain);
+
+        $return = $target->merge($source);
+        Assert::assertSame($target, $return, 'merge() must return it self');
+
+        Assert::assertEquals('bazInput', $target->getName(), 'getName() value not match');
+        Assert::assertEquals('bazErrorMessage', $target->getErrorMessage(), 'getErrorMessage() value not match');
+        Assert::assertEquals(true, $target->breakOnFailure(), 'breakOnFailure() value not match');
+        Assert::assertEquals(true, $target->isRequired(), 'isRequired() value not match');
+        Assert::assertEquals('bazRawValue', $target->getRawValue(), 'getRawValue() value not match');
     }
 
     /**
      * @return InputInterface
      */
     abstract protected function createDefaultInput();
+
+    /**
+     * @return MockObject|InputInterface
+     */
+    protected function createInputInterfaceMock()
+    {
+        /** @var InputInterface|MockObject $source */
+        $source = $this->getMock(InputInterface::class);
+
+        return $source;
+    }
+
+    /**
+     * @return MockObject|FilterChain
+     */
+    protected function createFilterChainMock()
+    {
+        /** @var FilterChain|MockObject $filterChain */
+        $filterChain = $this->getMock(FilterChain::class);
+
+        return $filterChain;
+    }
+
+    /**
+     * @return MockObject|ValidatorChain
+     */
+    protected function createValidatorChainMock()
+    {
+        /** @var ValidatorChain|MockObject $validatorChain */
+        $validatorChain = $this->getMock(ValidatorChain::class);
+
+        return $validatorChain;
+    }
 }

--- a/test/InputInterfaceTestTrait.php
+++ b/test/InputInterfaceTestTrait.php
@@ -6,6 +6,7 @@ use Maks3w\PhpUnitMethodsTrait\Framework\TestCaseTrait;
 use PHPUnit_Framework_Assert as Assert;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use PHPUnit_Framework_TestCase as TestCase;
+use stdClass;
 use Zend\Filter\FilterChain;
 use Zend\InputFilter\InputInterface;
 use Zend\Validator\ValidatorChain;
@@ -20,6 +21,146 @@ trait InputInterfaceTestTrait
     public function testImplementsInputInterface()
     {
         Assert::assertInstanceOf(InputInterface::class, $this->createDefaultInput());
+    }
+
+    public function testSetFilterChain()
+    {
+        $input = $this->createDefaultInput();
+        $filterChain = $this->createFilterChainMock();
+
+        $return = $input->setFilterChain($filterChain);
+        Assert::assertSame($input, $return, 'setFilterChain() must return it self');
+
+        Assert::assertSame($filterChain, $input->getFilterChain(), 'getFilterChain() value not match');
+    }
+
+    public function testSetValidatorChain()
+    {
+        $input = $this->createDefaultInput();
+        $validatorChain = $this->createValidatorChainMock();
+
+        $return = $input->setValidatorChain($validatorChain);
+        Assert::assertSame($input, $return, 'setValidatorChain() must return it self');
+
+        Assert::assertSame($validatorChain, $input->getValidatorChain(), 'getValidatorChain() value not match');
+    }
+
+    public function setRequiredProvider()
+    {
+        return [
+            // Description => [$isRequired]
+            'Enable' => [true],
+            'Disable' => [false],
+        ];
+    }
+
+    /**
+     * @dataProvider setRequiredProvider
+     */
+    public function testSetRequired($isRequired)
+    {
+        $input = $this->createDefaultInput();
+
+        $return = $input->setRequired($isRequired);
+        Assert::assertSame($input, $return, 'setRequired() must return it self');
+
+        Assert::assertEquals($isRequired, $input->isRequired(), 'isRequired() value not match');
+    }
+
+    public function setAllowEmptyProvider()
+    {
+        return [
+            // Description => [$allowEmpty]
+            'Enable' => [true],
+            'Disable' => [false],
+        ];
+    }
+
+    /**
+     * @dataProvider setAllowEmptyProvider
+     */
+    public function testSetAllowEmpty($allowEmpty)
+    {
+        $input = $this->createDefaultInput();
+
+        $return = $input->setAllowEmpty($allowEmpty);
+        Assert::assertSame($input, $return, 'setAllowEmpty() must return it self');
+
+        Assert::assertEquals($allowEmpty, $input->allowEmpty(), 'allowEmpty() value not match');
+    }
+
+    public function setBreakOnFailureProvider()
+    {
+        return [
+            // Description => [$breakOnFailure]
+            'Enable' => [true],
+            'Disable' => [false],
+        ];
+    }
+
+    /**
+     * @dataProvider setBreakOnFailureProvider
+     */
+    public function testSetBreakOnFailure($breakOnFailure)
+    {
+        $input = $this->createDefaultInput();
+
+        $return = $input->setBreakOnFailure($breakOnFailure);
+        Assert::assertSame($input, $return, 'setBreakOnFailure() must return it self');
+
+        Assert::assertEquals($breakOnFailure, $input->breakOnFailure(), 'breakOnFailure() value not match');
+    }
+
+    public function testSetErrorMessage()
+    {
+        $input = $this->createDefaultInput();
+
+        $return = $input->setErrorMessage('fooErrorMessage');
+        Assert::assertSame($input, $return, 'setErrorMessage() must return it self');
+
+        Assert::assertEquals('fooErrorMessage', $input->getErrorMessage(), 'getErrorMessage() value not match');
+    }
+
+    public function testSetName()
+    {
+        $input = $this->createDefaultInput();
+
+        $return = $input->setName('fooName');
+        Assert::assertSame($input, $return, 'setName() must return it self');
+
+        Assert::assertEquals('fooName', $input->getName(), 'getName() value not match');
+    }
+
+    public function setValueProvider()
+    {
+        $emptyValues = $this->emptyValueProvider();
+        $mixedValues = $this->mixedValueProvider();
+
+        $values = array_merge($emptyValues, $mixedValues);
+
+        return $values;
+    }
+
+    /**
+     * @dataProvider setValueProvider
+     */
+    public function testSetValue($value)
+    {
+        $filterChain = $this->createFilterChainMock();
+        $filterChain->expects(TestCase::atLeastOnce())
+            ->method('filter')
+            ->with($value)
+            ->willReturn('*filter*')
+        ;
+
+        $input = $this->createDefaultInput();
+        $input->setFilterChain($filterChain);
+
+        $return = $input->setValue($value);
+        Assert::assertSame($input, $return, 'setValue() must return it self');
+
+        Assert::assertEquals($value, $input->getRawValue(), 'getRawValue() value not match');
+        Assert::assertEquals('*filter*', $input->getValue(), 'getValue() value not match');
     }
 
     public function testMerge()
@@ -61,6 +202,37 @@ trait InputInterfaceTestTrait
         Assert::assertEquals(true, $target->breakOnFailure(), 'breakOnFailure() value not match');
         Assert::assertEquals(true, $target->isRequired(), 'isRequired() value not match');
         Assert::assertEquals('bazRawValue', $target->getRawValue(), 'getRawValue() value not match');
+    }
+
+    public function emptyValueProvider()
+    {
+        return [
+            // Description => [$value]
+            'null' => [null],
+            '""' => [''],
+            '"0"' => ['0'],
+            '0' => [0],
+            '0.0' => [0.0],
+            'false' => [false],
+            '[]' => [[]],
+        ];
+    }
+
+    public function mixedValueProvider()
+    {
+        return [
+            // Description => [$value]
+            'php' => ['php'],
+            'whitespace' => [' '],
+            '1' => [1],
+            '1.0' => [1.0],
+            'true' => [true],
+            '["php"]' => [['php']],
+            'object' => [new stdClass()],
+            // @formatter:off
+            'callable' => [function () {}],
+            // @formatter:on
+        ];
     }
 
     /**

--- a/test/InputInterfaceTestTrait.php
+++ b/test/InputInterfaceTestTrait.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace ZendTest\InputFilter;
+
+use PHPUnit_Framework_Assert as Assert;
+use Zend\InputFilter\InputInterface;
+
+/**
+ * Compliance test methods for `Zend\InputFilter\InputInterface` implementations.
+ */
+trait InputInterfaceTestTrait
+{
+    public function testImplementsInputInterface()
+    {
+        Assert::assertInstanceOf(InputInterface::class, $this->createDefaultInput());
+    }
+
+    /**
+     * @return InputInterface
+     */
+    abstract protected function createDefaultInput();
+}

--- a/test/InputInterfaceTestTrait.php
+++ b/test/InputInterfaceTestTrait.php
@@ -263,12 +263,20 @@ trait InputInterfaceTestTrait
     }
 
     /**
+     * @param null|bool $isValid If set stub isValid method for return the argument value.
+     *
      * @return MockObject|ValidatorChain
      */
-    protected function createValidatorChainMock()
+    protected function createValidatorChainMock($isValid = null)
     {
         /** @var ValidatorChain|MockObject $validatorChain */
         $validatorChain = $this->getMock(ValidatorChain::class);
+
+        if ($isValid !== null) {
+            $validatorChain->method('isValid')
+                ->willReturn($isValid)
+            ;
+        }
 
         return $validatorChain;
     }

--- a/test/InputProviderInterfaceTestTrait.php
+++ b/test/InputProviderInterfaceTestTrait.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace ZendTest\InputFilter;
+
+use PHPUnit_Framework_Assert as Assert;
+use Zend\InputFilter\InputProviderInterface;
+
+/**
+ * Compliance test methods for `Zend\InputFilter\InputProviderInterface` implementations.
+ */
+trait InputProviderInterfaceTestTrait
+{
+    public function testImplementsInputProviderInterface()
+    {
+        Assert::assertInstanceOf(InputProviderInterface::class, $this->createDefaultInputProvider());
+    }
+
+    /**
+     * @return InputProviderInterface
+     */
+    abstract protected function createDefaultInputProvider();
+}

--- a/test/InputTest.php
+++ b/test/InputTest.php
@@ -66,24 +66,6 @@ class InputTest extends TestCase
         $this->assertEquals(0, count($validators));
     }
 
-    public function testCanInjectFilterChain()
-    {
-        $input = $this->createDefaultInput();
-
-        $chain = new Filter\FilterChain();
-        $input->setFilterChain($chain);
-        $this->assertSame($chain, $input->getFilterChain());
-    }
-
-    public function testCanInjectValidatorChain()
-    {
-        $input = $this->createDefaultInput();
-
-        $chain = new Validator\ValidatorChain();
-        $input->setValidatorChain($chain);
-        $this->assertSame($chain, $input->getValidatorChain());
-    }
-
     public function testInputIsMarkedAsRequiredByDefault()
     {
         $input = $this->createDefaultInput();
@@ -91,27 +73,11 @@ class InputTest extends TestCase
         $this->assertTrue($input->isRequired());
     }
 
-    public function testRequiredFlagIsMutable()
-    {
-        $input = $this->createDefaultInput();
-
-        $input->setRequired(false);
-        $this->assertFalse($input->isRequired());
-    }
-
     public function testInputDoesNotAllowEmptyValuesByDefault()
     {
         $input = $this->createDefaultInput();
 
         $this->assertFalse($input->allowEmpty());
-    }
-
-    public function testAllowEmptyFlagIsMutable()
-    {
-        $input = $this->createDefaultInput();
-
-        $input->setAllowEmpty(true);
-        $this->assertTrue($input->allowEmpty());
     }
 
     public function testContinueIfEmptyFlagIsFalseByDefault()
@@ -136,34 +102,6 @@ class InputTest extends TestCase
         $input = $this->createDefaultInput();
 
         $this->assertNull($input->getValue());
-    }
-
-    public function testValueMayBeInjected()
-    {
-        $input = $this->createDefaultInput();
-
-        $input->setValue('bar');
-        $this->assertEquals('bar', $input->getValue());
-    }
-
-    public function testRetrievingValueFiltersTheValue()
-    {
-        $input = $this->createDefaultInput();
-
-        $input->setValue('bar');
-        $filter = new Filter\StringToUpper();
-        $input->getFilterChain()->attach($filter);
-        $this->assertEquals('BAR', $input->getValue());
-    }
-
-    public function testCanRetrieveRawValue()
-    {
-        $input = $this->createDefaultInput();
-
-        $input->setValue('bar');
-        $filter = new Filter\StringToUpper();
-        $input->getFilterChain()->attach($filter);
-        $this->assertEquals('bar', $input->getRawValue());
     }
 
     public function testIsValidReturnsFalseIfValidationChainFails()
@@ -229,14 +167,6 @@ class InputTest extends TestCase
         $input = $this->createDefaultInput();
 
         $this->assertFalse($input->breakOnFailure());
-    }
-
-    public function testBreakOnFailureFlagIsMutable()
-    {
-        $input = $this->createDefaultInput();
-
-        $input->setBreakOnFailure(true);
-        $this->assertTrue($input->breakOnFailure());
     }
 
     public function testNotEmptyValidatorAddedWhenIsValidIsCalled()

--- a/test/InputTest.php
+++ b/test/InputTest.php
@@ -477,7 +477,7 @@ class InputTest extends TestCase
      * @group 7448
      * @dataProvider whenRequiredAndAllowEmptyAndNotContinueIfEmptyValidatorsAreNotRun
      */
-    public function testWhenRequiredAndAllowEmptyAndNotContinueIfEmptyValidatorsAreNotRun($input, $value)
+    public function testWhenRequiredAndAllowEmptyAndNotContinueIfEmptyValidatorsAreNotRun(Input $input, $value)
     {
         $input->setValue($value);
         $this->assertTrue($input->isValid());
@@ -543,7 +543,7 @@ class InputTest extends TestCase
      * @group 7448
      * @dataProvider whenRequiredAndAllowEmptyAndContinueIfEmptyValidatorsAreRun
      */
-    public function testWhenRequiredAndAllowEmptyAndContinueIfEmptyValidatorsAreRun($input, $value, $assertion)
+    public function testWhenRequiredAndAllowEmptyAndContinueIfEmptyValidatorsAreRun(Input $input, $value, $assertion)
     {
         $input->setValue($value);
         $this->{$assertion}($input->isValid());
@@ -581,7 +581,7 @@ class InputTest extends TestCase
      * @group 7448
      * @dataProvider whenRequiredAndNotAllowEmptyAndNotContinueIfEmptyValidatorsAreNotRun
      */
-    public function testWhenRequiredAndNotAllowEmptyAndNotContinueIfEmptyValidatorsAreNotRun($input, $value)
+    public function testWhenRequiredAndNotAllowEmptyAndNotContinueIfEmptyValidatorsAreNotRun(Input $input, $value)
     {
         $input->setValue($value);
         $this->assertFalse($input->isValid());
@@ -647,7 +647,7 @@ class InputTest extends TestCase
      * @group 7448
      * @dataProvider whenRequiredAndNotAllowEmptyAndContinueIfEmptyValidatorsAreRun
      */
-    public function testWhenRequiredAndNotAllowEmptyAndContinueIfEmptyValidatorsAreRun($input, $value, $assertion)
+    public function testWhenRequiredAndNotAllowEmptyAndContinueIfEmptyValidatorsAreRun(Input $input, $value, $assertion)
     {
         $input->setValue($value);
         $this->{$assertion}($input->isValid());
@@ -685,7 +685,7 @@ class InputTest extends TestCase
      * @group 7448
      * @dataProvider whenNotRequiredAndAllowEmptyAndNotContinueIfEmptyValidatorsAreNotRun
      */
-    public function testWhenNotRequiredAndAllowEmptyAndNotContinueIfEmptyValidatorsAreNotRun($input, $value)
+    public function testWhenNotRequiredAndAllowEmptyAndNotContinueIfEmptyValidatorsAreNotRun(Input $input, $value)
     {
         $input->setValue($value);
         $this->assertTrue($input->isValid());
@@ -723,7 +723,7 @@ class InputTest extends TestCase
      * @group 7448
      * @dataProvider whenNotRequiredAndNotAllowEmptyAndNotContinueIfEmptyValidatorsAreNotRun
      */
-    public function testWhenNotRequiredAndNotAllowEmptyAndNotContinueIfEmptyValidatorsAreNotRun($input, $value)
+    public function testWhenNotRequiredAndNotAllowEmptyAndNotContinueIfEmptyValidatorsAreNotRun(Input $input, $value)
     {
         $input->setValue($value);
         $this->assertTrue($input->isValid());
@@ -789,7 +789,7 @@ class InputTest extends TestCase
      * @group 7448
      * @dataProvider whenNotRequiredAndAllowEmptyAndContinueIfEmptyValidatorsAreRun
      */
-    public function testWhenNotRequiredAndAllowEmptyAndContinueIfEmptyValidatorsAreRun($input, $value, $assertion)
+    public function testWhenNotRequiredAndAllowEmptyAndContinueIfEmptyValidatorsAreRun(Input $input, $value, $assertion)
     {
         $input->setValue($value);
         $this->{$assertion}($input->isValid());
@@ -855,7 +855,7 @@ class InputTest extends TestCase
      * @group 7448
      * @dataProvider whenNotRequiredAndNotAllowEmptyAndContinueIfEmptyValidatorsAreRun
      */
-    public function testWhenNotRequiredAndNotAllowEmptyAndContinueIfEmptyValidatorsAreRun($input, $value, $assertion)
+    public function testWhenNotRequiredAndNotAllowEmptyAndContinueIfEmptyValidatorsAreRun(Input $input, $value, $assertion)
     {
         $input->setValue($value);
         $this->{$assertion}($input->isValid());

--- a/test/InputTest.php
+++ b/test/InputTest.php
@@ -38,14 +38,14 @@ class InputTest extends TestCase
     public function testInputHasEmptyFilterChainByDefault()
     {
         $filters = $this->input->getFilterChain();
-        $this->assertInstanceOf('Zend\Filter\FilterChain', $filters);
+        $this->assertInstanceOf(Filter\FilterChain::class, $filters);
         $this->assertEquals(0, count($filters));
     }
 
     public function testInputHasEmptyValidatorChainByDefault()
     {
         $validators = $this->input->getValidatorChain();
-        $this->assertInstanceOf('Zend\Validator\ValidatorChain', $validators);
+        $this->assertInstanceOf(Validator\ValidatorChain::class, $validators);
         $this->assertEquals(0, count($validators));
     }
 
@@ -217,7 +217,7 @@ class InputTest extends TestCase
         $this->assertTrue($this->input->isRequired());
         $this->input->setValue('');
 
-        $notEmptyMock = $this->getMock('Zend\Validator\NotEmpty', ['isValid']);
+        $notEmptyMock = $this->getMock(Validator\NotEmpty::class, ['isValid']);
         $notEmptyMock->expects($this->exactly(1))
                      ->method('isValid')
                      ->will($this->returnValue(false));
@@ -333,10 +333,10 @@ class InputTest extends TestCase
         $this->assertEquals(1, $filterChain->count());
 
         $validators = $validatorChain->getValidators();
-        $this->assertInstanceOf('Zend\Validator\Digits', $validators[0]['instance']);
+        $this->assertInstanceOf(Validator\Digits::class, $validators[0]['instance']);
 
         $filters = $filterChain->getFilters()->toArray();
-        $this->assertInstanceOf('Zend\Filter\StringTrim', $filters[0]);
+        $this->assertInstanceOf(Filter\StringTrim::class, $filters[0]);
     }
 
     public function testDoNotInjectNotEmptyValidatorIfAnywhereInChain()
@@ -344,7 +344,7 @@ class InputTest extends TestCase
         $this->assertTrue($this->input->isRequired());
         $this->input->setValue('');
 
-        $notEmptyMock = $this->getMock('Zend\Validator\NotEmpty', ['isValid']);
+        $notEmptyMock = $this->getMock(Validator\NotEmpty::class, ['isValid']);
         $notEmptyMock->expects($this->exactly(1))
                      ->method('isValid')
                      ->will($this->returnValue(false));

--- a/test/InputTest.php
+++ b/test/InputTest.php
@@ -126,14 +126,14 @@ class InputTest extends TestCase
             'CIEmpty: T, AEmpty: T, Required: F, ValidChain: T'                   => [$cIEmpty, $isEmpty,  !$isRequired, $isValid,  $allValues,      $valid,  $noMessages],
             'CIEmpty: T, AEmpty: T, Required: F, ValidChain: F'                   => [$cIEmpty, $isEmpty,  !$isRequired, !$isValid, $allValues,      !$valid, $validatorMessages],
 
-            'CIEmpty: T, AEmpty: F, Required: T, ValidChain: T, Value: Empty'     => [$cIEmpty, !$isEmpty, $isRequired,  $isValid,  $emptyValues,    $valid,  $noMessages],
+            'CIEmpty: T, AEmpty: F, Required: T, ValidChain: T, Value: Empty'     => [$cIEmpty, !$isEmpty, $isRequired,  $isValid,  $emptyValues,    !$valid, $notEmptyMessages],
             'CIEmpty: T, AEmpty: F, Required: T, ValidChain: T, Value: Not Empty' => [$cIEmpty, !$isEmpty, $isRequired,  $isValid,  $nonEmptyValues, $valid,  $noMessages],
-            'CIEmpty: T, AEmpty: F, Required: T, ValidChain: F, Value: Empty'     => [$cIEmpty, !$isEmpty, $isRequired,  !$isValid, $emptyValues,    !$valid, $validatorMessages],
+            'CIEmpty: T, AEmpty: F, Required: T, ValidChain: F, Value: Empty'     => [$cIEmpty, !$isEmpty, $isRequired,  !$isValid, $emptyValues,    !$valid, $notEmptyAndVChain],
             'CIEmpty: T, AEmpty: F, Required: T, ValidChain: F, Value: Not Empty' => [$cIEmpty, !$isEmpty, $isRequired,  !$isValid, $nonEmptyValues, !$valid, $validatorMessages],
 
-            'CIEmpty: T, AEmpty: F, Required: F, ValidChain: T, Value: Empty'     => [$cIEmpty, !$isEmpty, !$isRequired, $isValid,  $emptyValues,    $valid,  $noMessages],
+            'CIEmpty: T, AEmpty: F, Required: F, ValidChain: T, Value: Empty'     => [$cIEmpty, !$isEmpty, !$isRequired, $isValid,  $emptyValues,    !$valid, $notEmptyMessages],
             'CIEmpty: T, AEmpty: F, Required: F, ValidChain: T, Value: Not Empty' => [$cIEmpty, !$isEmpty, !$isRequired, $isValid,  $nonEmptyValues, $valid,  $noMessages],
-            'CIEmpty: T, AEmpty: F, Required: F, ValidChain: F, Value: Empty'     => [$cIEmpty, !$isEmpty, !$isRequired, !$isValid, $emptyValues,    !$valid, $validatorMessages],
+            'CIEmpty: T, AEmpty: F, Required: F, ValidChain: F, Value: Empty'     => [$cIEmpty, !$isEmpty, !$isRequired, !$isValid, $emptyValues,    !$valid, $notEmptyAndVChain],
             'CIEmpty: T, AEmpty: F, Required: F, ValidChain: F, Value: Not Empty' => [$cIEmpty, !$isEmpty, !$isRequired, !$isValid, $nonEmptyValues, !$valid, $validatorMessages],
 
             'CIEmpty: F, AEmpty: T, Required: T, ValidChain: T'                   => [!$cIEmpty, $isEmpty,  $isRequired,  $isValid,  $allValues,      $valid,  $noMessages],
@@ -149,9 +149,9 @@ class InputTest extends TestCase
             'CIEmpty: F, AEmpty: F, Required: T, ValidChain: F, Value: Empty'     => [!$cIEmpty, !$isEmpty, $isRequired,  !$isValid, $emptyValues,    !$valid, $notEmptyMessages],
             'CIEmpty: F, AEmpty: F, Required: T, ValidChain: F, Value: Not Empty' => [!$cIEmpty, !$isEmpty, $isRequired,  !$isValid, $nonEmptyValues, !$valid, $validatorMessages],
 
-            'CIEmpty: F, AEmpty: F, Required: F, ValidChain: T, Value: Empty'     => [!$cIEmpty, !$isEmpty, !$isRequired, $isValid,  $emptyValues,    $valid,  $noMessages],
+            'CIEmpty: F, AEmpty: F, Required: F, ValidChain: T, Value: Empty'     => [!$cIEmpty, !$isEmpty, !$isRequired, $isValid,  $emptyValues,    !$valid, $notEmptyMessages],
             'CIEmpty: F, AEmpty: F, Required: F, ValidChain: T, Value: Not Empty' => [!$cIEmpty, !$isEmpty, !$isRequired, $isValid,  $nonEmptyValues, $valid,  $noMessages],
-            'CIEmpty: F, AEmpty: F, Required: F, ValidChain: F, Value: Empty'     => [!$cIEmpty, !$isEmpty, !$isRequired, !$isValid, $emptyValues,    $valid,  $noMessages],
+            'CIEmpty: F, AEmpty: F, Required: F, ValidChain: F, Value: Empty'     => [!$cIEmpty, !$isEmpty, !$isRequired, !$isValid, $emptyValues,    !$valid, $notEmptyMessages],
             'CIEmpty: F, AEmpty: F, Required: F, ValidChain: F, Value: Not Empty' => [!$cIEmpty, !$isEmpty, !$isRequired, !$isValid, $nonEmptyValues, !$valid, $validatorMessages],
         ];
         // @codingStandardsIgnoreEnd

--- a/test/InputTest.php
+++ b/test/InputTest.php
@@ -24,69 +24,77 @@ class InputTest extends TestCase
     use EmptyContextInterfaceTestTrait;
     use InputInterfaceTestTrait;
 
-    /**
-     * @var Input
-     */
-    protected $input;
-
-    public function setUp()
-    {
-        $this->input = new Input('foo');
-    }
-
     public function testConstructorRequiresAName()
     {
-        $this->assertEquals('foo', $this->input->getName());
+        $input = $this->createDefaultInput();
+
+        $this->assertEquals('foo', $input->getName());
     }
 
     public function testInputHasEmptyFilterChainByDefault()
     {
-        $filters = $this->input->getFilterChain();
+        $input = $this->createDefaultInput();
+
+        $filters = $input->getFilterChain();
         $this->assertInstanceOf(Filter\FilterChain::class, $filters);
         $this->assertEquals(0, count($filters));
     }
 
     public function testInputHasEmptyValidatorChainByDefault()
     {
-        $validators = $this->input->getValidatorChain();
+        $input = $this->createDefaultInput();
+
+        $validators = $input->getValidatorChain();
         $this->assertInstanceOf(Validator\ValidatorChain::class, $validators);
         $this->assertEquals(0, count($validators));
     }
 
     public function testCanInjectFilterChain()
     {
+        $input = $this->createDefaultInput();
+
         $chain = new Filter\FilterChain();
-        $this->input->setFilterChain($chain);
-        $this->assertSame($chain, $this->input->getFilterChain());
+        $input->setFilterChain($chain);
+        $this->assertSame($chain, $input->getFilterChain());
     }
 
     public function testCanInjectValidatorChain()
     {
+        $input = $this->createDefaultInput();
+
         $chain = new Validator\ValidatorChain();
-        $this->input->setValidatorChain($chain);
-        $this->assertSame($chain, $this->input->getValidatorChain());
+        $input->setValidatorChain($chain);
+        $this->assertSame($chain, $input->getValidatorChain());
     }
 
     public function testInputIsMarkedAsRequiredByDefault()
     {
-        $this->assertTrue($this->input->isRequired());
+        $input = $this->createDefaultInput();
+
+        $this->assertTrue($input->isRequired());
     }
 
     public function testRequiredFlagIsMutable()
     {
-        $this->input->setRequired(false);
-        $this->assertFalse($this->input->isRequired());
+        $input = $this->createDefaultInput();
+
+        $input->setRequired(false);
+        $this->assertFalse($input->isRequired());
     }
 
     public function testInputDoesNotAllowEmptyValuesByDefault()
     {
-        $this->assertFalse($this->input->allowEmpty());
+        $input = $this->createDefaultInput();
+
+        $this->assertFalse($input->allowEmpty());
     }
 
     public function testAllowEmptyFlagIsMutable()
     {
-        $this->input->setAllowEmpty(true);
-        $this->assertTrue($this->input->allowEmpty());
+        $input = $this->createDefaultInput();
+
+        $input->setAllowEmpty(true);
+        $this->assertTrue($input->allowEmpty());
     }
 
     public function testContinueIfEmptyFlagIsFalseByDefault()
@@ -115,111 +123,137 @@ class InputTest extends TestCase
 
     public function testValueIsNullByDefault()
     {
-        $this->assertNull($this->input->getValue());
+        $input = $this->createDefaultInput();
+
+        $this->assertNull($input->getValue());
     }
 
     public function testValueMayBeInjected()
     {
-        $this->input->setValue('bar');
-        $this->assertEquals('bar', $this->input->getValue());
+        $input = $this->createDefaultInput();
+
+        $input->setValue('bar');
+        $this->assertEquals('bar', $input->getValue());
     }
 
     public function testRetrievingValueFiltersTheValue()
     {
-        $this->input->setValue('bar');
+        $input = $this->createDefaultInput();
+
+        $input->setValue('bar');
         $filter = new Filter\StringToUpper();
-        $this->input->getFilterChain()->attach($filter);
-        $this->assertEquals('BAR', $this->input->getValue());
+        $input->getFilterChain()->attach($filter);
+        $this->assertEquals('BAR', $input->getValue());
     }
 
     public function testCanRetrieveRawValue()
     {
-        $this->input->setValue('bar');
+        $input = $this->createDefaultInput();
+
+        $input->setValue('bar');
         $filter = new Filter\StringToUpper();
-        $this->input->getFilterChain()->attach($filter);
-        $this->assertEquals('bar', $this->input->getRawValue());
+        $input->getFilterChain()->attach($filter);
+        $this->assertEquals('bar', $input->getRawValue());
     }
 
     public function testIsValidReturnsFalseIfValidationChainFails()
     {
-        $this->input->setValue('bar');
+        $input = $this->createDefaultInput();
+
+        $input->setValue('bar');
         $validator = new Validator\Digits();
-        $this->input->getValidatorChain()->attach($validator);
-        $this->assertFalse($this->input->isValid());
+        $input->getValidatorChain()->attach($validator);
+        $this->assertFalse($input->isValid());
     }
 
     public function testIsValidReturnsTrueIfValidationChainSucceeds()
     {
-        $this->input->setValue('123');
+        $input = $this->createDefaultInput();
+
+        $input->setValue('123');
         $validator = new Validator\Digits();
-        $this->input->getValidatorChain()->attach($validator);
-        $this->assertTrue($this->input->isValid());
+        $input->getValidatorChain()->attach($validator);
+        $this->assertTrue($input->isValid());
     }
 
     public function testValidationOperatesOnFilteredValue()
     {
-        $this->input->setValue(' 123 ');
+        $input = $this->createDefaultInput();
+
+        $input->setValue(' 123 ');
         $filter = new Filter\StringTrim();
-        $this->input->getFilterChain()->attach($filter);
+        $input->getFilterChain()->attach($filter);
         $validator = new Validator\Digits();
-        $this->input->getValidatorChain()->attach($validator);
-        $this->assertTrue($this->input->isValid());
+        $input->getValidatorChain()->attach($validator);
+        $this->assertTrue($input->isValid());
     }
 
     public function testGetMessagesReturnsValidationMessages()
     {
-        $this->input->setValue('bar');
+        $input = $this->createDefaultInput();
+
+        $input->setValue('bar');
         $validator = new Validator\Digits();
-        $this->input->getValidatorChain()->attach($validator);
-        $this->assertFalse($this->input->isValid());
-        $messages = $this->input->getMessages();
+        $input->getValidatorChain()->attach($validator);
+        $this->assertFalse($input->isValid());
+        $messages = $input->getMessages();
         $this->assertArrayHasKey(Validator\Digits::NOT_DIGITS, $messages);
     }
 
     public function testSpecifyingMessagesToInputReturnsThoseOnFailedValidation()
     {
-        $this->input->setValue('bar');
+        $input = $this->createDefaultInput();
+
+        $input->setValue('bar');
         $validator = new Validator\Digits();
-        $this->input->getValidatorChain()->attach($validator);
-        $this->input->setErrorMessage('Please enter only digits');
-        $this->assertFalse($this->input->isValid());
-        $messages = $this->input->getMessages();
+        $input->getValidatorChain()->attach($validator);
+        $input->setErrorMessage('Please enter only digits');
+        $this->assertFalse($input->isValid());
+        $messages = $input->getMessages();
         $this->assertArrayNotHasKey(Validator\Digits::NOT_DIGITS, $messages);
         $this->assertContains('Please enter only digits', $messages);
     }
 
     public function testBreakOnFailureFlagIsOffByDefault()
     {
-        $this->assertFalse($this->input->breakOnFailure());
+        $input = $this->createDefaultInput();
+
+        $this->assertFalse($input->breakOnFailure());
     }
 
     public function testBreakOnFailureFlagIsMutable()
     {
-        $this->input->setBreakOnFailure(true);
-        $this->assertTrue($this->input->breakOnFailure());
+        $input = $this->createDefaultInput();
+
+        $input->setBreakOnFailure(true);
+        $this->assertTrue($input->breakOnFailure());
     }
 
     public function testNotEmptyValidatorAddedWhenIsValidIsCalled()
     {
-        $this->assertTrue($this->input->isRequired());
-        $this->input->setValue('');
-        $validatorChain = $this->input->getValidatorChain();
+        $input = $this->createDefaultInput();
+
+        $this->assertTrue($input->isRequired());
+        $input->setValue('');
+        $validatorChain = $input->getValidatorChain();
         $this->assertEquals(0, count($validatorChain->getValidators()));
 
-        $this->assertFalse($this->input->isValid());
-        $messages = $this->input->getMessages();
+        $this->assertFalse($input->isValid());
+        $messages = $input->getMessages();
         $this->assertArrayHasKey('isEmpty', $messages);
         $this->assertEquals(1, count($validatorChain->getValidators()));
 
         // Assert that NotEmpty validator wasn't added again
-        $this->assertFalse($this->input->isValid());
+        $this->assertFalse($input->isValid());
         $this->assertEquals(1, count($validatorChain->getValidators()));
     }
 
     public function testRequiredNotEmptyValidatorNotAddedWhenOneExists()
     {
-        $this->assertTrue($this->input->isRequired());
-        $this->input->setValue('');
+        $input = $this->createDefaultInput();
+
+        $this->assertTrue($input->isRequired());
+        $input->setValue('');
 
         /** @var Validator\NotEmpty|MockObject $notEmptyMock */
         $notEmptyMock = $this->getMock(Validator\NotEmpty::class, ['isValid']);
@@ -227,9 +261,9 @@ class InputTest extends TestCase
                      ->method('isValid')
                      ->will($this->returnValue(false));
 
-        $validatorChain = $this->input->getValidatorChain();
+        $validatorChain = $input->getValidatorChain();
         $validatorChain->prependValidator($notEmptyMock);
-        $this->assertFalse($this->input->isValid());
+        $this->assertFalse($input->isValid());
 
         $validators = $validatorChain->getValidators();
         $this->assertEquals(1, count($validators));
@@ -250,35 +284,45 @@ class InputTest extends TestCase
      */
     public function testValidatorSkippedIfValueIsEmptyAndAllowedAndNotContinue($emptyValue)
     {
+        $input = $this->createDefaultInput();
+
         $validator = function () {
             return false;
         };
-        $this->input->setAllowEmpty(true)
+        $input->setAllowEmpty(true)
             ->setContinueIfEmpty(false)
             ->setValue($emptyValue)
             ->getValidatorChain()->attach(new Validator\Callback($validator));
 
-        $this->assertTrue($this->input->isValid());
+        $this->assertTrue($input->isValid());
     }
 
     /**
      * @dataProvider emptyValuesProvider
      */
-    public function testAllowEmptyOptionSet($emptyValue)
+    public function testAllowEmptyOptionSet($emptyValue, $input = null)
     {
-        $this->input->setAllowEmpty(true);
-        $this->input->setValue($emptyValue);
-        $this->assertTrue($this->input->isValid());
+        if (empty($input)) {
+            $input = $this->createDefaultInput();
+        }
+
+        $input->setAllowEmpty(true);
+        $input->setValue($emptyValue);
+        $this->assertTrue($input->isValid());
     }
 
     /**
      * @dataProvider emptyValuesProvider
      */
-    public function testAllowEmptyOptionNotSet($emptyValue)
+    public function testAllowEmptyOptionNotSet($emptyValue, $input = null)
     {
-        $this->input->setAllowEmpty(false);
-        $this->input->setValue($emptyValue);
-        $this->assertFalse($this->input->isValid());
+        if (empty($input)) {
+            $input = $this->createDefaultInput();
+        }
+
+        $input->setAllowEmpty(false);
+        $input->setValue($emptyValue);
+        $this->assertFalse($input->isValid());
     }
 
     /**
@@ -286,37 +330,43 @@ class InputTest extends TestCase
      */
     public function testValidatorInvokedIfValueIsEmptyAndAllowedAndContinue($emptyValue)
     {
+        $input = $this->createDefaultInput();
+
         $message = 'failure by explicit validator';
         $validator = new Validator\Callback(function ($value) {
             return false;
         });
         $validator->setMessage($message);
-        $this->input->setAllowEmpty(true)
+        $input->setAllowEmpty(true)
                     ->setContinueIfEmpty(true)
                     ->setValue($emptyValue)
                     ->getValidatorChain()->attach($validator);
-        $this->assertFalse($this->input->isValid());
+        $this->assertFalse($input->isValid());
         // Test reason for validation failure; ensures that failure was not
         // caused by accidentally injected NotEmpty validator
-        $this->assertEquals(['callbackValue' => $message], $this->input->getMessages());
+        $this->assertEquals(['callbackValue' => $message], $input->getMessages());
     }
 
     public function testNotAllowEmptyWithFilterConvertsNonemptyToEmptyIsNotValid()
     {
-        $this->input->setValue('nonempty')
+        $input = $this->createDefaultInput();
+
+        $input->setValue('nonempty')
                     ->getFilterChain()->attach(new Filter\Callback(function () {
                         return '';
                     }));
-        $this->assertFalse($this->input->isValid());
+        $this->assertFalse($input->isValid());
     }
 
     public function testNotAllowEmptyWithFilterConvertsEmptyToNonEmptyIsValid()
     {
-        $this->input->setValue('')
+        $input = $this->createDefaultInput();
+
+        $input->setValue('')
                     ->getFilterChain()->attach(new Filter\Callback(function () {
                         return 'nonempty';
                     }));
-        $this->assertTrue($this->input->isValid());
+        $this->assertTrue($input->isValid());
     }
 
     public function testMerge()
@@ -346,8 +396,10 @@ class InputTest extends TestCase
 
     public function testDoNotInjectNotEmptyValidatorIfAnywhereInChain()
     {
-        $this->assertTrue($this->input->isRequired());
-        $this->input->setValue('');
+        $input = $this->createDefaultInput();
+
+        $this->assertTrue($input->isRequired());
+        $input->setValue('');
 
         /** @var Validator\NotEmpty|MockObject $notEmptyMock */
         $notEmptyMock = $this->getMock(Validator\NotEmpty::class, ['isValid']);
@@ -355,10 +407,10 @@ class InputTest extends TestCase
                      ->method('isValid')
                      ->will($this->returnValue(false));
 
-        $validatorChain = $this->input->getValidatorChain();
+        $validatorChain = $input->getValidatorChain();
         $validatorChain->attach(new Validator\Digits());
         $validatorChain->attach($notEmptyMock);
-        $this->assertFalse($this->input->isValid());
+        $this->assertFalse($input->isValid());
 
         $validators = $validatorChain->getValidators();
         $this->assertEquals(2, count($validators));
@@ -385,14 +437,16 @@ class InputTest extends TestCase
      */
     public function testFallbackValue($fallbackValue)
     {
-        $this->input->setFallbackValue($fallbackValue);
-        $validator = new Validator\Date();
-        $this->input->getValidatorChain()->attach($validator);
-        $this->input->setValue('123'); // not a date
+        $input = $this->createDefaultInput();
 
-        $this->assertTrue($this->input->isValid());
-        $this->assertEmpty($this->input->getMessages());
-        $this->assertSame($fallbackValue, $this->input->getValue());
+        $input->setFallbackValue($fallbackValue);
+        $validator = new Validator\Date();
+        $input->getValidatorChain()->attach($validator);
+        $input->setValue('123'); // not a date
+
+        $this->assertTrue($input->isValid());
+        $this->assertEmpty($input->getMessages());
+        $this->assertSame($fallbackValue, $input->getValue());
     }
 
     public function testMergeRetainsContinueIfEmptyFlag()
@@ -871,7 +925,7 @@ class InputTest extends TestCase
 
     protected function createDefaultInput()
     {
-        $input = new Input();
+        $input = new Input('foo');
 
         return $input;
     }

--- a/test/InputTest.php
+++ b/test/InputTest.php
@@ -99,20 +99,20 @@ class InputTest extends TestCase
 
     public function testContinueIfEmptyFlagIsFalseByDefault()
     {
-        $input = new Input('foo');
+        $input = $this->createDefaultInput();
         $this->assertFalse($input->continueIfEmpty());
     }
 
     public function testContinueIfEmptyFlagIsMutable()
     {
-        $input = new Input('foo');
+        $input = $this->createDefaultInput();
         $input->setContinueIfEmpty(true);
         $this->assertTrue($input->continueIfEmpty());
     }
 
     public function testNotEmptyValidatorNotInjectedIfContinueIfEmptyIsTrue()
     {
-        $input = new Input('foo');
+        $input = $this->createDefaultInput();
         $input->setContinueIfEmpty(true);
         $input->setValue('');
         $input->isValid();
@@ -371,7 +371,7 @@ class InputTest extends TestCase
 
     public function testMerge()
     {
-        $input = new Input('foo');
+        $input = $this->createDefaultInput();
         $input->setValue(' 123 ');
         $filter = new Filter\StringTrim();
         $input->getFilterChain()->attach($filter);
@@ -451,7 +451,7 @@ class InputTest extends TestCase
 
     public function testMergeRetainsContinueIfEmptyFlag()
     {
-        $input = new Input('foo');
+        $input = $this->createDefaultInput();
         $input->setContinueIfEmpty(true);
 
         $input2 = new Input('bar');
@@ -461,7 +461,7 @@ class InputTest extends TestCase
 
     public function testMergeRetainsAllowEmptyFlag()
     {
-        $input = new Input('foo');
+        $input = $this->createDefaultInput();
         $input->setRequired(true);
         $input->setAllowEmpty(true);
 
@@ -479,7 +479,7 @@ class InputTest extends TestCase
      */
     public function testInputIsValidWhenUsingSetRequiredAtStart()
     {
-        $input = new Input();
+        $input = $this->createDefaultInput();
         $input->setName('foo')
               ->setRequired(false)
               ->setAllowEmpty(false)
@@ -493,7 +493,7 @@ class InputTest extends TestCase
      */
     public function testInputIsValidWhenUsingSetRequiredAtEnd()
     {
-        $input = new Input();
+        $input = $this->createDefaultInput();
         $input->setName('foo')
               ->setAllowEmpty(false)
               ->setContinueIfEmpty(false)
@@ -508,13 +508,13 @@ class InputTest extends TestCase
             throw new RuntimeException('Validator executed when it should not be');
         });
 
-        $requiredFirst = new Input('foo');
+        $requiredFirst = $this->createDefaultInput();
         $requiredFirst->setRequired(true)
             ->setAllowEmpty(true)
             ->setContinueIfEmpty(false)
             ->getValidatorChain()->attach($validator);
 
-        $requiredLast = new Input('foo');
+        $requiredLast = $this->createDefaultInput();
         $requiredLast->setAllowEmpty(true)
             ->setContinueIfEmpty(false)
             ->setRequired(true)
@@ -556,16 +556,16 @@ class InputTest extends TestCase
             return true;
         });
 
-        $requiredFirstInvalid = new Input('foo');
-        $requiredFirstValid   = new Input('foo');
+        $requiredFirstInvalid = $this->createDefaultInput();
+        $requiredFirstValid   = $this->createDefaultInput();
         foreach ([$requiredFirstValid, $requiredFirstInvalid] as $input) {
             $input->setRequired(true)
                 ->setAllowEmpty(true)
                 ->setContinueIfEmpty(true);
         }
 
-        $requiredLastInvalid = new Input('foo');
-        $requiredLastValid   = new Input('foo');
+        $requiredLastInvalid = $this->createDefaultInput();
+        $requiredLastValid   = $this->createDefaultInput();
         foreach ([$requiredLastValid, $requiredLastInvalid] as $input) {
             $input->setAllowEmpty(true)
                 ->setContinueIfEmpty(true)
@@ -612,13 +612,13 @@ class InputTest extends TestCase
             throw new RuntimeException('Validator executed when it should not be');
         });
 
-        $requiredFirst = new Input('foo');
+        $requiredFirst = $this->createDefaultInput();
         $requiredFirst->setRequired(true)
             ->setAllowEmpty(false)
             ->setContinueIfEmpty(false)
             ->getValidatorChain()->attach($validator);
 
-        $requiredLast = new Input('foo');
+        $requiredLast = $this->createDefaultInput();
         $requiredLast->setAllowEmpty(false)
             ->setContinueIfEmpty(false)
             ->setRequired(true)
@@ -660,16 +660,16 @@ class InputTest extends TestCase
             return true;
         });
 
-        $requiredFirstInvalid = new Input('foo');
-        $requiredFirstValid   = new Input('foo');
+        $requiredFirstInvalid = $this->createDefaultInput();
+        $requiredFirstValid   = $this->createDefaultInput();
         foreach ([$requiredFirstValid, $requiredFirstInvalid] as $input) {
             $input->setRequired(true)
                 ->setAllowEmpty(false)
                 ->setContinueIfEmpty(true);
         }
 
-        $requiredLastInvalid = new Input('foo');
-        $requiredLastValid   = new Input('foo');
+        $requiredLastInvalid = $this->createDefaultInput();
+        $requiredLastValid   = $this->createDefaultInput();
         foreach ([$requiredLastValid, $requiredLastInvalid] as $input) {
             $input->setAllowEmpty(false)
                 ->setContinueIfEmpty(true)
@@ -716,13 +716,13 @@ class InputTest extends TestCase
             throw new RuntimeException('Validator executed when it should not be');
         });
 
-        $requiredFirst = new Input('foo');
+        $requiredFirst = $this->createDefaultInput();
         $requiredFirst->setRequired(false)
             ->setAllowEmpty(true)
             ->setContinueIfEmpty(false)
             ->getValidatorChain()->attach($validator);
 
-        $requiredLast = new Input('foo');
+        $requiredLast = $this->createDefaultInput();
         $requiredLast->setAllowEmpty(true)
             ->setContinueIfEmpty(false)
             ->setRequired(false)
@@ -754,13 +754,13 @@ class InputTest extends TestCase
             throw new RuntimeException('Validator executed when it should not be');
         });
 
-        $requiredFirst = new Input('foo');
+        $requiredFirst = $this->createDefaultInput();
         $requiredFirst->setRequired(false)
             ->setAllowEmpty(false)
             ->setContinueIfEmpty(false)
             ->getValidatorChain()->attach($validator);
 
-        $requiredLast = new Input('foo');
+        $requiredLast = $this->createDefaultInput();
         $requiredLast->setAllowEmpty(false)
             ->setContinueIfEmpty(false)
             ->setRequired(false)
@@ -802,16 +802,16 @@ class InputTest extends TestCase
             return true;
         });
 
-        $requiredFirstInvalid = new Input('foo');
-        $requiredFirstValid   = new Input('foo');
+        $requiredFirstInvalid = $this->createDefaultInput();
+        $requiredFirstValid   = $this->createDefaultInput();
         foreach ([$requiredFirstValid, $requiredFirstInvalid] as $input) {
             $input->setRequired(false)
                 ->setAllowEmpty(true)
                 ->setContinueIfEmpty(true);
         }
 
-        $requiredLastInvalid = new Input('foo');
-        $requiredLastValid   = new Input('foo');
+        $requiredLastInvalid = $this->createDefaultInput();
+        $requiredLastValid   = $this->createDefaultInput();
         foreach ([$requiredLastValid, $requiredLastInvalid] as $input) {
             $input->setAllowEmpty(true)
                 ->setContinueIfEmpty(true)
@@ -868,16 +868,16 @@ class InputTest extends TestCase
             return true;
         });
 
-        $requiredFirstInvalid = new Input('foo');
-        $requiredFirstValid   = new Input('foo');
+        $requiredFirstInvalid = $this->createDefaultInput();
+        $requiredFirstValid   = $this->createDefaultInput();
         foreach ([$requiredFirstValid, $requiredFirstInvalid] as $input) {
             $input->setRequired(false)
                 ->setAllowEmpty(false)
                 ->setContinueIfEmpty(true);
         }
 
-        $requiredLastInvalid = new Input('foo');
-        $requiredLastValid   = new Input('foo');
+        $requiredLastInvalid = $this->createDefaultInput();
+        $requiredLastValid   = $this->createDefaultInput();
         foreach ([$requiredLastValid, $requiredLastInvalid] as $input) {
             $input->setAllowEmpty(false)
                 ->setContinueIfEmpty(true)

--- a/test/InputTest.php
+++ b/test/InputTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\InputFilter;
 
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use PHPUnit_Framework_TestCase as TestCase;
 use RuntimeException;
 use Zend\Filter;
@@ -217,6 +218,7 @@ class InputTest extends TestCase
         $this->assertTrue($this->input->isRequired());
         $this->input->setValue('');
 
+        /** @var Validator\NotEmpty|MockObject $notEmptyMock */
         $notEmptyMock = $this->getMock(Validator\NotEmpty::class, ['isValid']);
         $notEmptyMock->expects($this->exactly(1))
                      ->method('isValid')
@@ -344,6 +346,7 @@ class InputTest extends TestCase
         $this->assertTrue($this->input->isRequired());
         $this->input->setValue('');
 
+        /** @var Validator\NotEmpty|MockObject $notEmptyMock */
         $notEmptyMock = $this->getMock(Validator\NotEmpty::class, ['isValid']);
         $notEmptyMock->expects($this->exactly(1))
                      ->method('isValid')

--- a/test/InputTest.php
+++ b/test/InputTest.php
@@ -103,13 +103,6 @@ class InputTest extends TestCase
         $this->assertFalse($input->continueIfEmpty());
     }
 
-    public function testContinueIfEmptyFlagIsMutable()
-    {
-        $input = $this->createDefaultInput();
-        $input->setContinueIfEmpty(true);
-        $this->assertTrue($input->continueIfEmpty());
-    }
-
     public function testNotEmptyValidatorNotInjectedIfContinueIfEmptyIsTrue()
     {
         $input = $this->createDefaultInput();

--- a/test/InputTest.php
+++ b/test/InputTest.php
@@ -95,6 +95,109 @@ class InputTest extends TestCase
         $this->assertEquals(true, $target->continueIfEmpty(), 'continueIfEmpty() value not match');
     }
 
+    public function testAllowEmptyVsIsRequiredVsIsValidRules()
+    {
+        $this->markTestSkipped('Supersede by testInputContinueIfEmptyAllowEmptyVsIsRequiredVsIsValidRules');
+    }
+
+    public function continueIfEmptyVsAllowEmptyVsIsRequiredVsIsValidProviderRules()
+    {
+        $allValues = $this->setValueProvider();
+        $emptyValues = $this->emptyValueProvider();
+        $nonEmptyValues = array_diff_key($allValues, $emptyValues);
+
+        $cIEmpty = true;
+        $isEmpty = true;
+        $isRequired = true;
+        $isValid = true;
+        $valid = true;
+
+        $noMessages = [];
+        $notEmptyMessages = ['isEmpty' => "Value is required and can't be empty"];
+        $validatorMessages = ['callbackValue' => 'The input is not valid'];
+        $notEmptyAndVChain = array_merge($notEmptyMessages, $validatorMessages);
+
+        // @codingStandardsIgnoreStart
+        $dataTemplates = [
+            // Description => [$cIEmpty, $allowEmpty, $isRequired, $isValid, $valuesToTest, $expectedIsValid, $expectedMessages]
+            'CIEmpty: T, AEmpty: T, Required: T, ValidChain: T'                   => [$cIEmpty, $isEmpty,  $isRequired,  $isValid,  $allValues,      $valid,  $noMessages],
+            'CIEmpty: T, AEmpty: T, Required: T, ValidChain: F'                   => [$cIEmpty, $isEmpty,  $isRequired,  !$isValid, $allValues,      !$valid, $validatorMessages],
+
+            'CIEmpty: T, AEmpty: T, Required: F, ValidChain: T'                   => [$cIEmpty, $isEmpty,  !$isRequired, $isValid,  $allValues,      $valid,  $noMessages],
+            'CIEmpty: T, AEmpty: T, Required: F, ValidChain: F'                   => [$cIEmpty, $isEmpty,  !$isRequired, !$isValid, $allValues,      !$valid, $validatorMessages],
+
+            'CIEmpty: T, AEmpty: F, Required: T, ValidChain: T, Value: Empty'     => [$cIEmpty, !$isEmpty, $isRequired,  $isValid,  $emptyValues,    $valid,  $noMessages],
+            'CIEmpty: T, AEmpty: F, Required: T, ValidChain: T, Value: Not Empty' => [$cIEmpty, !$isEmpty, $isRequired,  $isValid,  $nonEmptyValues, $valid,  $noMessages],
+            'CIEmpty: T, AEmpty: F, Required: T, ValidChain: F, Value: Empty'     => [$cIEmpty, !$isEmpty, $isRequired,  !$isValid, $emptyValues,    !$valid, $validatorMessages],
+            'CIEmpty: T, AEmpty: F, Required: T, ValidChain: F, Value: Not Empty' => [$cIEmpty, !$isEmpty, $isRequired,  !$isValid, $nonEmptyValues, !$valid, $validatorMessages],
+
+            'CIEmpty: T, AEmpty: F, Required: F, ValidChain: T, Value: Empty'     => [$cIEmpty, !$isEmpty, !$isRequired, $isValid,  $emptyValues,    $valid,  $noMessages],
+            'CIEmpty: T, AEmpty: F, Required: F, ValidChain: T, Value: Not Empty' => [$cIEmpty, !$isEmpty, !$isRequired, $isValid,  $nonEmptyValues, $valid,  $noMessages],
+            'CIEmpty: T, AEmpty: F, Required: F, ValidChain: F, Value: Empty'     => [$cIEmpty, !$isEmpty, !$isRequired, !$isValid, $emptyValues,    !$valid, $validatorMessages],
+            'CIEmpty: T, AEmpty: F, Required: F, ValidChain: F, Value: Not Empty' => [$cIEmpty, !$isEmpty, !$isRequired, !$isValid, $nonEmptyValues, !$valid, $validatorMessages],
+
+            'CIEmpty: F, AEmpty: T, Required: T, ValidChain: T'                   => [!$cIEmpty, $isEmpty,  $isRequired,  $isValid,  $allValues,      $valid,  $noMessages],
+            'CIEmpty: F, AEmpty: T, Required: T, ValidChain: F, Value: Empty'     => [!$cIEmpty, $isEmpty,  $isRequired,  !$isValid, $emptyValues,    $valid,  $noMessages],
+            'CIEmpty: F, AEmpty: T, Required: T, ValidChain: F, Value: Not Empty' => [!$cIEmpty, $isEmpty,  $isRequired,  !$isValid, $nonEmptyValues, !$valid, $validatorMessages],
+
+            'CIEmpty: F, AEmpty: T, Required: F, ValidChain: T'                   => [!$cIEmpty, $isEmpty,  !$isRequired, $isValid,  $allValues,      $valid,  $noMessages],
+            'CIEmpty: F, AEmpty: T, Required: F, ValidChain: F, Value: Empty'     => [!$cIEmpty, $isEmpty,  !$isRequired, !$isValid, $emptyValues,    $valid,  $noMessages],
+            'CIEmpty: F, AEmpty: T, Required: F, ValidChain: F, Value: Not Empty' => [!$cIEmpty, $isEmpty,  !$isRequired, !$isValid, $nonEmptyValues, !$valid, $validatorMessages],
+
+            'CIEmpty: F, AEmpty: F, Required: T, ValidChain: T, Value: Empty'     => [!$cIEmpty, !$isEmpty, $isRequired,  $isValid,  $emptyValues,    !$valid, $notEmptyMessages],
+            'CIEmpty: F, AEmpty: F, Required: T, ValidChain: T, Value: Not Empty' => [!$cIEmpty, !$isEmpty, $isRequired,  $isValid,  $nonEmptyValues, $valid,  $noMessages],
+            'CIEmpty: F, AEmpty: F, Required: T, ValidChain: F, Value: Empty'     => [!$cIEmpty, !$isEmpty, $isRequired,  !$isValid, $emptyValues,    !$valid, $notEmptyMessages],
+            'CIEmpty: F, AEmpty: F, Required: T, ValidChain: F, Value: Not Empty' => [!$cIEmpty, !$isEmpty, $isRequired,  !$isValid, $nonEmptyValues, !$valid, $validatorMessages],
+
+            'CIEmpty: F, AEmpty: F, Required: F, ValidChain: T, Value: Empty'     => [!$cIEmpty, !$isEmpty, !$isRequired, $isValid,  $emptyValues,    $valid,  $noMessages],
+            'CIEmpty: F, AEmpty: F, Required: F, ValidChain: T, Value: Not Empty' => [!$cIEmpty, !$isEmpty, !$isRequired, $isValid,  $nonEmptyValues, $valid,  $noMessages],
+            'CIEmpty: F, AEmpty: F, Required: F, ValidChain: F, Value: Empty'     => [!$cIEmpty, !$isEmpty, !$isRequired, !$isValid, $emptyValues,    $valid,  $noMessages],
+            'CIEmpty: F, AEmpty: F, Required: F, ValidChain: F, Value: Not Empty' => [!$cIEmpty, !$isEmpty, !$isRequired, !$isValid, $nonEmptyValues, !$valid, $validatorMessages],
+        ];
+        // @codingStandardsIgnoreEnd
+
+
+        // Expand data template matrix for each possible input value.
+        // Description => [$cIEmpty, $allowEmpty, $isRequired, $isValid, $value, $expectedIsValid, $expectedMessages]
+        foreach ($dataTemplates as $dataTemplateDescription => $dataTemplate) {
+            $temporalTemplate = $dataTemplate;
+            foreach ($dataTemplate[4] as $valueDescription => $value) {
+                $temporalTemplate[4] = current($value);
+                yield $dataTemplateDescription . ' / ' . $valueDescription => $temporalTemplate;
+            }
+        }
+    }
+
+    /**
+     * @dataProvider continueIfEmptyVsAllowEmptyVsIsRequiredVsIsValidProviderRules
+     */
+    public function testInputContinueIfEmptyAllowEmptyVsIsRequiredVsIsValidRules(
+        $continueIfEmpty,
+        $allowEmpty,
+        $isRequired,
+        $isValid,
+        $value,
+        $expectedIsValid,
+        $expectedMessages
+    ) {
+        $input = $this->createDefaultInput();
+
+        $input->setAllowEmpty($allowEmpty);
+        $input->setContinueIfEmpty($continueIfEmpty);
+        $input->setRequired($isRequired);
+        $input->setValidatorChain($this->createValidatorChainMock($isValid));
+        $input->setValue($value);
+
+        $this->assertEquals(
+            $expectedIsValid,
+            $input->isValid(),
+            'isValid() value not match. Detail: ' . json_encode($input->getMessages())
+        );
+        $this->assertEquals($expectedMessages, $input->getMessages(), 'getMessages() value not match');
+        $this->assertEquals($value, $input->getRawValue(), 'getRawValue() must return the value always');
+        $this->assertEquals($value, $input->getValue(), 'getValue() must return the filtered value always');
+    }
+
     public function testInputHasEmptyFilterChainByDefault()
     {
         $input = $this->createDefaultInput();

--- a/test/InputTest.php
+++ b/test/InputTest.php
@@ -31,6 +31,23 @@ class InputTest extends TestCase
         $this->assertEquals('foo', $input->getName());
     }
 
+    /**
+     * Specific Input::merge extras
+     */
+    public function testInputMerge()
+    {
+        $source = new Input();
+        $source->setContinueIfEmpty(true);
+
+        $target = $this->createDefaultInput();
+        $target->setContinueIfEmpty(false);
+
+        $return = $target->merge($source);
+        $this->assertSame($target, $return, 'merge() must return it self');
+
+        $this->assertEquals(true, $target->continueIfEmpty(), 'continueIfEmpty() value not match');
+    }
+
     public function testInputHasEmptyFilterChainByDefault()
     {
         $input = $this->createDefaultInput();
@@ -362,31 +379,6 @@ class InputTest extends TestCase
         $this->assertTrue($input->isValid());
     }
 
-    public function testMerge()
-    {
-        $input = $this->createDefaultInput();
-        $input->setValue(' 123 ');
-        $filter = new Filter\StringTrim();
-        $input->getFilterChain()->attach($filter);
-        $validator = new Validator\Digits();
-        $input->getValidatorChain()->attach($validator);
-
-        $input2 = new Input('bar');
-        $input2->merge($input);
-        $validatorChain = $input->getValidatorChain();
-        $filterChain    = $input->getFilterChain();
-
-        $this->assertEquals(' 123 ', $input2->getRawValue());
-        $this->assertEquals(1, $validatorChain->count());
-        $this->assertEquals(1, $filterChain->count());
-
-        $validators = $validatorChain->getValidators();
-        $this->assertInstanceOf(Validator\Digits::class, $validators[0]['instance']);
-
-        $filters = $filterChain->getFilters()->toArray();
-        $this->assertInstanceOf(Filter\StringTrim::class, $filters[0]);
-    }
-
     public function testDoNotInjectNotEmptyValidatorIfAnywhereInChain()
     {
         $input = $this->createDefaultInput();
@@ -440,31 +432,6 @@ class InputTest extends TestCase
         $this->assertTrue($input->isValid());
         $this->assertEmpty($input->getMessages());
         $this->assertSame($fallbackValue, $input->getValue());
-    }
-
-    public function testMergeRetainsContinueIfEmptyFlag()
-    {
-        $input = $this->createDefaultInput();
-        $input->setContinueIfEmpty(true);
-
-        $input2 = new Input('bar');
-        $input2->merge($input);
-        $this->assertTrue($input2->continueIfEmpty());
-    }
-
-    public function testMergeRetainsAllowEmptyFlag()
-    {
-        $input = $this->createDefaultInput();
-        $input->setRequired(true);
-        $input->setAllowEmpty(true);
-
-        $input2 = new Input('bar');
-        $input2->setRequired(true);
-        $input2->setAllowEmpty(false);
-        $input2->merge($input);
-
-        $this->assertTrue($input2->isRequired());
-        $this->assertTrue($input2->allowEmpty());
     }
 
     /**

--- a/test/InputTest.php
+++ b/test/InputTest.php
@@ -21,6 +21,9 @@ use Zend\Validator;
  */
 class InputTest extends TestCase
 {
+    use EmptyContextInterfaceTestTrait;
+    use InputInterfaceTestTrait;
+
     /**
      * @var Input
      */
@@ -859,5 +862,17 @@ class InputTest extends TestCase
     {
         $input->setValue($value);
         $this->{$assertion}($input->isValid());
+    }
+
+    protected function createDefaultEmptyContext()
+    {
+        return $this->createDefaultInput();
+    }
+
+    protected function createDefaultInput()
+    {
+        $input = new Input();
+
+        return $input;
     }
 }

--- a/test/InputTest.php
+++ b/test/InputTest.php
@@ -15,6 +15,9 @@ use Zend\Filter;
 use Zend\InputFilter\Input;
 use Zend\Validator;
 
+/**
+ * @covers Zend\InputFilter\Input
+ */
 class InputTest extends TestCase
 {
     /**

--- a/test/ReplaceableInputInterfaceTestTrait.php
+++ b/test/ReplaceableInputInterfaceTestTrait.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace ZendTest\InputFilter;
+
+use PHPUnit_Framework_Assert as Assert;
+use Zend\InputFilter\ReplaceableInputInterface;
+
+/**
+ * Compliance test methods for `Zend\InputFilter\ReplaceableInputInterface` implementations.
+ */
+trait ReplaceableInputInterfaceTestTrait
+{
+    public function testImplementsReplaceableInputInterface()
+    {
+        Assert::assertInstanceOf(ReplaceableInputInterface::class, $this->createDefaultReplaceableInput());
+    }
+
+    /**
+     * @return ReplaceableInputInterface
+     */
+    abstract protected function createDefaultReplaceableInput();
+}

--- a/test/UnknownInputsCapableInterfaceTestTrait.php
+++ b/test/UnknownInputsCapableInterfaceTestTrait.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace ZendTest\InputFilter;
+
+use PHPUnit_Framework_Assert as Assert;
+use Zend\InputFilter\UnknownInputsCapableInterface;
+
+/**
+ * Compliance test methods for `Zend\InputFilter\UnknownInputsCapableInterface` implementations.
+ */
+trait UnknownInputsCapableInterfaceTestTrait
+{
+    public function testImplementsUnknownInputsCapableInterface()
+    {
+        Assert::assertInstanceOf(UnknownInputsCapableInterface::class, $this->createDefaultUnknownInputsCapable());
+    }
+
+    /**
+     * @return UnknownInputsCapableInterface
+     */
+    abstract protected function createDefaultUnknownInputsCapable();
+}

--- a/test/UnknownInputsCapableInterfaceTestTrait.php
+++ b/test/UnknownInputsCapableInterfaceTestTrait.php
@@ -2,7 +2,10 @@
 
 namespace ZendTest\InputFilter;
 
+use Exception;
 use PHPUnit_Framework_Assert as Assert;
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\InputFilter\Exception\RuntimeException;
 use Zend\InputFilter\UnknownInputsCapableInterface;
 
 /**
@@ -13,6 +16,32 @@ trait UnknownInputsCapableInterfaceTestTrait
     public function testImplementsUnknownInputsCapableInterface()
     {
         Assert::assertInstanceOf(UnknownInputsCapableInterface::class, $this->createDefaultUnknownInputsCapable());
+    }
+
+    public function testHasUnknownThrowExceptionIfDataWasNotSetYet()
+    {
+        $filter = $this->createDefaultUnknownInputsCapable();
+        $expectedExceptionType = RuntimeException::class;
+
+        try {
+            $filter->hasUnknown();
+            TestCase::fail('Expected exception ' . $expectedExceptionType . ' was not thrown');
+        } catch (Exception $e) {
+            Assert::assertInstanceOf($expectedExceptionType, $e);
+        }
+    }
+
+    public function testGetUnknownThrowExceptionIfDataWasNotSetYet()
+    {
+        $filter = $this->createDefaultUnknownInputsCapable();
+        $expectedExceptionType = RuntimeException::class;
+
+        try {
+            $filter->getUnknown();
+            TestCase::fail('Expected exception ' . $expectedExceptionType . ' was not thrown');
+        } catch (Exception $e) {
+            Assert::assertInstanceOf($expectedExceptionType, $e);
+        }
     }
 
     /**


### PR DESCRIPTION
From the first commit up to `Improve PHPDoc types` (a6e9b0c) It's basically CS.

To be backported to 2.4 LTS:

* `Consolidation of Factory Exception expectations + namespe bug`
* `[Factory] Fix unsafe call non InputInterface methods`
* `Consolidation of InputInterface::merge and Fix unsafe merging`
* `Fix allow_empty / continue_if_empty cases`

This PR could be partial merge at least up to the commit `Assert objects are instances of the expected type` and the three commits from above

PHP < 5.5 Incompatibilties:

* Use of FQDN::class constant instead FQDN string
* Use of yield keyword
