### PR TITLE
Remove test about Input setters permutation

### DIFF
--- a/test/InputTest.php
+++ b/test/InputTest.php
@@ -411,34 +411,6 @@ class InputTest extends TestCase
         $this->assertTrue($input2->allowEmpty());
     }
 
-    /**
-     * @group 7445
-     */
-    public function testInputIsValidWhenUsingSetRequiredAtStart()
-    {
-        $input = new Input();
-        $input->setName('foo')
-              ->setRequired(false)
-              ->setAllowEmpty(false)
-              ->setContinueIfEmpty(false);
-
-        $this->assertTrue($input->isValid());
-    }
-
-    /**
-     * @group 7445
-     */
-    public function testInputIsValidWhenUsingSetRequiredAtEnd()
-    {
-        $input = new Input();
-        $input->setName('foo')
-              ->setAllowEmpty(false)
-              ->setContinueIfEmpty(false)
-              ->setRequired(false);
-
-        $this->assertTrue($input->isValid());
-    }
-
     public function whenRequiredAndAllowEmptyAndNotContinueIfEmptyValidatorsAreNotRun()
     {
         $validator = new Validator\Callback(function ($value) {
@@ -451,19 +423,10 @@ class InputTest extends TestCase
             ->setContinueIfEmpty(false)
             ->getValidatorChain()->attach($validator);
 
-        $requiredLast = new Input('foo');
-        $requiredLast->setAllowEmpty(true)
-            ->setContinueIfEmpty(false)
-            ->setRequired(true)
-            ->getValidatorChain()->attach($validator);
-
         return [
             'required-first-null'  => [$requiredFirst, null],
-            'required-last-null'   => [$requiredLast, null],
             'required-first-empty' => [$requiredFirst, ''],
-            'required-last-empty'  => [$requiredLast, ''],
             'required-first-array' => [$requiredFirst, []],
-            'required-last-array'  => [$requiredLast, []],
         ];
     }
 
@@ -494,42 +457,22 @@ class InputTest extends TestCase
         });
 
         $requiredFirstInvalid = new Input('foo');
+        $requiredFirstInvalid->getValidatorChain()->attach($alwaysInvalid);
         $requiredFirstValid   = new Input('foo');
+        $requiredFirstValid->getValidatorChain()->attach($emptyIsValid);
         foreach ([$requiredFirstValid, $requiredFirstInvalid] as $input) {
             $input->setRequired(true)
                 ->setAllowEmpty(true)
                 ->setContinueIfEmpty(true);
         }
 
-        $requiredLastInvalid = new Input('foo');
-        $requiredLastValid   = new Input('foo');
-        foreach ([$requiredLastValid, $requiredLastInvalid] as $input) {
-            $input->setAllowEmpty(true)
-                ->setContinueIfEmpty(true)
-                ->setRequired(true);
-        }
-
-        foreach ([$requiredFirstValid, $requiredLastValid] as $input) {
-            $input->getValidatorChain()->attach($emptyIsValid);
-        }
-
-        foreach ([$requiredFirstInvalid, $requiredLastInvalid] as $input) {
-            $input->getValidatorChain()->attach($alwaysInvalid);
-        }
-
         return [
             'required-first-null-valid'    => [$requiredFirstValid, null, 'assertTrue'],
             'required-first-null-invalid'  => [$requiredFirstInvalid, null, 'assertFalse'],
-            'required-last-null-valid'     => [$requiredLastValid, null, 'assertTrue'],
-            'required-last-null-invalid'   => [$requiredLastInvalid, null, 'assertFalse'],
             'required-first-empty-valid'   => [$requiredFirstValid, '', 'assertTrue'],
             'required-first-empty-invalid' => [$requiredFirstInvalid, '', 'assertFalse'],
-            'required-last-empty-valid'    => [$requiredLastValid, '', 'assertTrue'],
-            'required-last-empty-invalid'  => [$requiredLastInvalid, '', 'assertFalse'],
             'required-first-array-valid'   => [$requiredFirstValid, [], 'assertTrue'],
             'required-first-array-invalid' => [$requiredFirstInvalid, [], 'assertFalse'],
-            'required-last-array-valid'    => [$requiredLastValid, [], 'assertTrue'],
-            'required-last-array-invalid'  => [$requiredLastInvalid, [], 'assertFalse'],
         ];
     }
 
@@ -555,19 +498,10 @@ class InputTest extends TestCase
             ->setContinueIfEmpty(false)
             ->getValidatorChain()->attach($validator);
 
-        $requiredLast = new Input('foo');
-        $requiredLast->setAllowEmpty(false)
-            ->setContinueIfEmpty(false)
-            ->setRequired(true)
-            ->getValidatorChain()->attach($validator);
-
         return [
             'required-first-null'  => [$requiredFirst, null],
-            'required-last-null'   => [$requiredLast, null],
             'required-first-empty' => [$requiredFirst, ''],
-            'required-last-empty'  => [$requiredLast, ''],
             'required-first-array' => [$requiredFirst, []],
-            'required-last-array'  => [$requiredLast, []],
         ];
     }
 
@@ -598,42 +532,22 @@ class InputTest extends TestCase
         });
 
         $requiredFirstInvalid = new Input('foo');
+        $requiredFirstInvalid->getValidatorChain()->attach($alwaysInvalid);
         $requiredFirstValid   = new Input('foo');
+        $requiredFirstValid->getValidatorChain()->attach($emptyIsValid);
         foreach ([$requiredFirstValid, $requiredFirstInvalid] as $input) {
             $input->setRequired(true)
                 ->setAllowEmpty(false)
                 ->setContinueIfEmpty(true);
         }
 
-        $requiredLastInvalid = new Input('foo');
-        $requiredLastValid   = new Input('foo');
-        foreach ([$requiredLastValid, $requiredLastInvalid] as $input) {
-            $input->setAllowEmpty(false)
-                ->setContinueIfEmpty(true)
-                ->setRequired(true);
-        }
-
-        foreach ([$requiredFirstValid, $requiredLastValid] as $input) {
-            $input->getValidatorChain()->attach($emptyIsValid);
-        }
-
-        foreach ([$requiredFirstInvalid, $requiredLastInvalid] as $input) {
-            $input->getValidatorChain()->attach($alwaysInvalid);
-        }
-
         return [
             'required-first-null-valid'    => [$requiredFirstValid, null, 'assertTrue'],
             'required-first-null-invalid'  => [$requiredFirstInvalid, null, 'assertFalse'],
-            'required-last-null-valid'     => [$requiredLastValid, null, 'assertTrue'],
-            'required-last-null-invalid'   => [$requiredLastInvalid, null, 'assertFalse'],
             'required-first-empty-valid'   => [$requiredFirstValid, '', 'assertTrue'],
             'required-first-empty-invalid' => [$requiredFirstInvalid, '', 'assertFalse'],
-            'required-last-empty-valid'    => [$requiredLastValid, '', 'assertTrue'],
-            'required-last-empty-invalid'  => [$requiredLastInvalid, '', 'assertFalse'],
             'required-first-array-valid'   => [$requiredFirstValid, [], 'assertTrue'],
             'required-first-array-invalid' => [$requiredFirstInvalid, [], 'assertFalse'],
-            'required-last-array-valid'    => [$requiredLastValid, [], 'assertTrue'],
-            'required-last-array-invalid'  => [$requiredLastInvalid, [], 'assertFalse'],
         ];
     }
 
@@ -659,19 +573,10 @@ class InputTest extends TestCase
             ->setContinueIfEmpty(false)
             ->getValidatorChain()->attach($validator);
 
-        $requiredLast = new Input('foo');
-        $requiredLast->setAllowEmpty(true)
-            ->setContinueIfEmpty(false)
-            ->setRequired(false)
-            ->getValidatorChain()->attach($validator);
-
         return [
             'required-first-null'  => [$requiredFirst, null],
-            'required-last-null'   => [$requiredLast, null],
             'required-first-empty' => [$requiredFirst, ''],
-            'required-last-empty'  => [$requiredLast, ''],
             'required-first-array' => [$requiredFirst, []],
-            'required-last-array'  => [$requiredLast, []],
         ];
     }
 
@@ -697,19 +602,10 @@ class InputTest extends TestCase
             ->setContinueIfEmpty(false)
             ->getValidatorChain()->attach($validator);
 
-        $requiredLast = new Input('foo');
-        $requiredLast->setAllowEmpty(false)
-            ->setContinueIfEmpty(false)
-            ->setRequired(false)
-            ->getValidatorChain()->attach($validator);
-
         return [
             'required-first-null'  => [$requiredFirst, null],
-            'required-last-null'   => [$requiredLast, null],
             'required-first-empty' => [$requiredFirst, ''],
-            'required-last-empty'  => [$requiredLast, ''],
             'required-first-array' => [$requiredFirst, []],
-            'required-last-array'  => [$requiredLast, []],
         ];
     }
 
@@ -740,42 +636,22 @@ class InputTest extends TestCase
         });
 
         $requiredFirstInvalid = new Input('foo');
+        $requiredFirstInvalid->getValidatorChain()->attach($alwaysInvalid);
         $requiredFirstValid   = new Input('foo');
+        $requiredFirstValid->getValidatorChain()->attach($emptyIsValid);
         foreach ([$requiredFirstValid, $requiredFirstInvalid] as $input) {
             $input->setRequired(false)
                 ->setAllowEmpty(true)
                 ->setContinueIfEmpty(true);
         }
 
-        $requiredLastInvalid = new Input('foo');
-        $requiredLastValid   = new Input('foo');
-        foreach ([$requiredLastValid, $requiredLastInvalid] as $input) {
-            $input->setAllowEmpty(true)
-                ->setContinueIfEmpty(true)
-                ->setRequired(false);
-        }
-
-        foreach ([$requiredFirstValid, $requiredLastValid] as $input) {
-            $input->getValidatorChain()->attach($emptyIsValid);
-        }
-
-        foreach ([$requiredFirstInvalid, $requiredLastInvalid] as $input) {
-            $input->getValidatorChain()->attach($alwaysInvalid);
-        }
-
         return [
             'required-first-null-valid'    => [$requiredFirstValid, null, 'assertTrue'],
             'required-first-null-invalid'  => [$requiredFirstInvalid, null, 'assertFalse'],
-            'required-last-null-valid'     => [$requiredLastValid, null, 'assertTrue'],
-            'required-last-null-invalid'   => [$requiredLastInvalid, null, 'assertFalse'],
             'required-first-empty-valid'   => [$requiredFirstValid, '', 'assertTrue'],
             'required-first-empty-invalid' => [$requiredFirstInvalid, '', 'assertFalse'],
-            'required-last-empty-valid'    => [$requiredLastValid, '', 'assertTrue'],
-            'required-last-empty-invalid'  => [$requiredLastInvalid, '', 'assertFalse'],
             'required-first-array-valid'   => [$requiredFirstValid, [], 'assertTrue'],
             'required-first-array-invalid' => [$requiredFirstInvalid, [], 'assertFalse'],
-            'required-last-array-valid'    => [$requiredLastValid, [], 'assertTrue'],
-            'required-last-array-invalid'  => [$requiredLastInvalid, [], 'assertFalse'],
         ];
     }
 
@@ -806,42 +682,22 @@ class InputTest extends TestCase
         });
 
         $requiredFirstInvalid = new Input('foo');
+        $requiredFirstInvalid->getValidatorChain()->attach($alwaysInvalid);
         $requiredFirstValid   = new Input('foo');
+        $requiredFirstValid->getValidatorChain()->attach($emptyIsValid);
         foreach ([$requiredFirstValid, $requiredFirstInvalid] as $input) {
             $input->setRequired(false)
                 ->setAllowEmpty(false)
                 ->setContinueIfEmpty(true);
         }
 
-        $requiredLastInvalid = new Input('foo');
-        $requiredLastValid   = new Input('foo');
-        foreach ([$requiredLastValid, $requiredLastInvalid] as $input) {
-            $input->setAllowEmpty(false)
-                ->setContinueIfEmpty(true)
-                ->setRequired(false);
-        }
-
-        foreach ([$requiredFirstValid, $requiredLastValid] as $input) {
-            $input->getValidatorChain()->attach($emptyIsValid);
-        }
-
-        foreach ([$requiredFirstInvalid, $requiredLastInvalid] as $input) {
-            $input->getValidatorChain()->attach($alwaysInvalid);
-        }
-
         return [
             'required-first-null-valid'    => [$requiredFirstValid, null, 'assertTrue'],
             'required-first-null-invalid'  => [$requiredFirstInvalid, null, 'assertFalse'],
-            'required-last-null-valid'     => [$requiredLastValid, null, 'assertTrue'],
-            'required-last-null-invalid'   => [$requiredLastInvalid, null, 'assertFalse'],
             'required-first-empty-valid'   => [$requiredFirstValid, '', 'assertTrue'],
             'required-first-empty-invalid' => [$requiredFirstInvalid, '', 'assertFalse'],
-            'required-last-empty-valid'    => [$requiredLastValid, '', 'assertTrue'],
-            'required-last-empty-invalid'  => [$requiredLastInvalid, '', 'assertFalse'],
             'required-first-array-valid'   => [$requiredFirstValid, [], 'assertTrue'],
             'required-first-array-invalid' => [$requiredFirstInvalid, [], 'assertFalse'],
-            'required-last-array-valid'    => [$requiredLastValid, [], 'assertTrue'],
-            'required-last-array-invalid'  => [$requiredLastInvalid, [], 'assertFalse'],
         ];
     }
 


### PR DESCRIPTION
These tests asserts the state of Input is always the same not matter the order when invoke the setters.

Sometime ago there was specific tweaks where setterA change the default value for propertieB. This feature was removed so this tests are verifyng "Feature X" not longer exists.

This given me to think if we should to test every permutation on setters call and I found it's not. There is no reason for to test a feature not longer exists.


PD: setRequired is already verified by testRequiredFlagIsMutable