### PR TITLE
Make symmetric the scenarios when required is true/false

### DIFF
--- a/src/ArrayInput.php
+++ b/src/ArrayInput.php
@@ -84,10 +84,6 @@ class ArrayInput extends Input
         $result    = true;
         foreach ($values as $value) {
             $empty = ($value === null || $value === '' || $value === []);
-            if ($empty && !$this->isRequired() && !$this->continueIfEmpty()) {
-                $result = true;
-                continue;
-            }
             if ($empty && $this->allowEmpty() && !$this->continueIfEmpty()) {
                 $result = true;
                 continue;

--- a/src/FileInput.php
+++ b/src/FileInput.php
@@ -130,10 +130,6 @@ class FileInput extends Input
             return false;
         }
 
-        if ($empty && ! $required && ! $continueIfEmpty) {
-            return true;
-        }
-
         if ($empty && $allowEmpty && ! $continueIfEmpty) {
             return true;
         }

--- a/src/Input.php
+++ b/src/Input.php
@@ -409,10 +409,6 @@ class Input implements
             return false;
         }
 
-        if ($empty && ! $required && ! $continueIfEmpty) {
-            return true;
-        }
-
         if ($empty && $allowEmpty && ! $continueIfEmpty) {
             return true;
         }

--- a/test/CollectionInputFilterTest.php
+++ b/test/CollectionInputFilterTest.php
@@ -101,21 +101,17 @@ class CollectionInputFilterTest extends TestCase
             [
                 'foo' => ' bazbat ',
                 'bar' => '12345',
-                'baz' => '',
                 'nest' => [
                     'foo' => ' bazbat ',
                     'bar' => '12345',
-                    'baz' => '',
                 ],
             ],
             [
                 'foo' => ' batbaz ',
                 'bar' => '54321',
-                'baz' => '',
                 'nest' => [
                     'foo' => ' batbaz ',
                     'bar' => '54321',
-                    'baz' => '',
                 ],
             ]
         ];
@@ -307,7 +303,7 @@ class CollectionInputFilterTest extends TestCase
 
         $this->assertCount(2, $this->filter->getValidInput());
         foreach ($this->filter->getValidInput() as $validInputs) {
-            $this->assertCount(4, $validInputs);
+            $this->assertCount(3, $validInputs);
         }
     }
 
@@ -360,31 +356,25 @@ class CollectionInputFilterTest extends TestCase
             [
                 'foo' => ' bazbattoolong ',
                 'bar' => '12345',
-                'baz' => '',
                 'nest' => [
                     'foo' => ' bazbat ',
                     'bar' => '12345',
-                    'baz' => '',
                 ],
             ],
             [
                 'foo' => ' bazbat ',
                 'bar' => 'notstring',
-                'baz' => '',
                 'nest' => [
                     'foo' => ' bazbat ',
                     'bar' => '12345',
-                    'baz' => '',
                 ],
             ],
             [
                 'foo' => ' bazbat ',
                 'bar' => '12345',
-                'baz' => '',
                 'nest' => [
                     // missing 'foo' here
                     'bar' => '12345',
-                    'baz' => '',
                 ],
             ],
         ];
@@ -506,7 +496,6 @@ class CollectionInputFilterTest extends TestCase
                 'nest' => [
                     'foo' => ' bazbat ',
                     'bar' => '12345',
-                    'baz' => '',
                 ],
             ]
         ];

--- a/test/FileInputTest.php
+++ b/test/FileInputTest.php
@@ -433,6 +433,9 @@ class FileInputTest extends InputTest
         unset($dataSets['Required: T; AEmpty: F; CIEmpty: F; Validator: X, Value: Empty / tmp_name']);
         unset($dataSets['Required: T; AEmpty: F; CIEmpty: F; Validator: X, Value: Empty / single']);
         unset($dataSets['Required: T; AEmpty: F; CIEmpty: F; Validator: X, Value: Empty / multi']);
+        unset($dataSets['Required: F; AEmpty: F; CIEmpty: F; Validator: X, Value: Empty / tmp_name']);
+        unset($dataSets['Required: F; AEmpty: F; CIEmpty: F; Validator: X, Value: Empty / single']);
+        unset($dataSets['Required: F; AEmpty: F; CIEmpty: F; Validator: X, Value: Empty / multi']);
 
         return $dataSets;
     }

--- a/test/InputTest.php
+++ b/test/InputTest.php
@@ -655,7 +655,7 @@ class InputTest extends TestCase
             'Required: F; AEmpty: F; CIEmpty: T; Validator: T'                   => [!$isRequired, !$aEmpty,  $cIEmpty, $validatorValid  , $allValues     ,  $isValid, []],
             'Required: F; AEmpty: F; CIEmpty: T; Validator: F'                   => [!$isRequired, !$aEmpty,  $cIEmpty, $validatorInvalid, $allValues     , !$isValid, $validatorMsg],
 
-            'Required: F; AEmpty: F; CIEmpty: F; Validator: X, Value: Empty'     => [!$isRequired, !$aEmpty, !$cIEmpty, $validatorNotCall, $emptyValues   ,  $isValid, []],
+            'Required: F; AEmpty: F; CIEmpty: F; Validator: X, Value: Empty'     => [!$isRequired, !$aEmpty, !$cIEmpty, $validatorNotCall, $emptyValues   , !$isValid, $notEmptyMsg],
             'Required: F; AEmpty: F; CIEmpty: F; Validator: T, Value: Not Empty' => [!$isRequired, !$aEmpty, !$cIEmpty, $validatorValid  , $nonEmptyValues,  $isValid, []],
             'Required: F; AEmpty: F; CIEmpty: F; Validator: F, Value: Not Empty' => [!$isRequired, !$aEmpty, !$cIEmpty, $validatorInvalid, $nonEmptyValues, !$isValid, $validatorMsg],
         ];


### PR DESCRIPTION
There is no reason for to have differences when required is true or false and the value is always set.