### PR TITLE
Not set default required error message always

### DIFF
--- a/src/ArrayInput.php
+++ b/src/ArrayInput.php
@@ -70,7 +70,9 @@ class ArrayInput extends Input
         }
 
         if (! $hasValue && $required) {
-            $this->setErrorMessage('Value is required');
+            if ($this->errorMessage === null) {
+                $this->setErrorMessage('Value is required');
+            }
             return false;
         }
 

--- a/src/FileInput.php
+++ b/src/FileInput.php
@@ -124,7 +124,9 @@ class FileInput extends Input
         }
 
         if (! $hasValue && $required && ! $this->hasFallback()) {
-            $this->setErrorMessage('Value is required');
+            if ($this->errorMessage === null) {
+                $this->setErrorMessage('Value is required');
+            }
             return false;
         }
 

--- a/src/Input.php
+++ b/src/Input.php
@@ -403,7 +403,9 @@ class Input implements
         }
 
         if (! $hasValue && $required) {
-            $this->setErrorMessage('Value is required');
+            if ($this->errorMessage === null) {
+                $this->setErrorMessage('Value is required');
+            }
             return false;
         }
 

--- a/test/InputTest.php
+++ b/test/InputTest.php
@@ -175,6 +175,19 @@ class InputTest extends TestCase
         $this->assertEquals(['Value is required'], $input->getMessages(), 'getMessages() value not match');
     }
 
+    public function testRequiredWithoutFallbackAndValueNotSetThenFailWithCustomErrorMessage()
+    {
+        $input = $this->input;
+        $input->setRequired(true);
+        $input->setErrorMessage('fooErrorMessage');
+
+        $this->assertFalse(
+            $input->isValid(),
+            'isValid() should be return always false when no fallback value, is required, and not data is set.'
+        );
+        $this->assertEquals(['fooErrorMessage'], $input->getMessages(), 'getMessages() value not match');
+    }
+
     public function testNotRequiredWithoutFallbackAndValueNotSetThenIsValid()
     {
         $input = $this->input;


### PR DESCRIPTION
Skip if a previous one was set

Partial fix for #28.

This does not allow to translate automatically with multiple localizations.