### PR TITLE
Provide NotEmpty::IS_EMPTY validation message for required input

### DIFF
--- a/src/ArrayInput.php
+++ b/src/ArrayInput.php
@@ -71,7 +71,7 @@ class ArrayInput extends Input
 
         if (! $hasValue && $required) {
             if ($this->errorMessage === null) {
-                $this->setErrorMessage('Value is required');
+                $this->errorMessage = $this->prepareRequiredValidationFailureMessage();
             }
             return false;
         }

--- a/src/FileInput.php
+++ b/src/FileInput.php
@@ -125,7 +125,7 @@ class FileInput extends Input
 
         if (! $hasValue && $required && ! $this->hasFallback()) {
             if ($this->errorMessage === null) {
-                $this->setErrorMessage('Value is required');
+                $this->errorMessage = $this->prepareRequiredValidationFailureMessage();
             }
             return false;
         }

--- a/src/Input.php
+++ b/src/Input.php
@@ -404,7 +404,7 @@ class Input implements
 
         if (! $hasValue && $required) {
             if ($this->errorMessage === null) {
-                $this->setErrorMessage('Value is required');
+                $this->errorMessage = $this->prepareRequiredValidationFailureMessage();
             }
             return false;
         }
@@ -482,5 +482,19 @@ class Input implements
         }
 
         $chain->prependValidator(new NotEmpty(), true);
+    }
+
+    /**
+     * Create and return the validation failure message for required input.
+     *
+     * @return string[]
+     */
+    protected function prepareRequiredValidationFailureMessage()
+    {
+        $notEmpty = new NotEmpty();
+        $templates = $notEmpty->getOption('messageTemplates');
+        return [
+            NotEmpty::IS_EMPTY => $templates[NotEmpty::IS_EMPTY],
+        ];
     }
 }

--- a/test/InputTest.php
+++ b/test/InputTest.php
@@ -42,15 +42,12 @@ class InputTest extends TestCase
 
         $messages = $input->getMessages();
         $this->assertInternalType('array', $messages, $message . ' non-array messages array');
-        $this->assertArrayHasKey(NotEmpty::IS_EMPTY, $messages, $message . ' missing NotEmpty::IS_EMPTY key');
 
         $notEmpty         = new NotEmpty();
         $messageTemplates = $notEmpty->getOption('messageTemplates');
-        $this->assertEquals(
-            $messageTemplates[NotEmpty::IS_EMPTY],
-            $messages[NotEmpty::IS_EMPTY],
-            $message . ' NotEmpty::IS_EMPTY message differs'
-        );
+        $this->assertSame([
+            NotEmpty::IS_EMPTY => $messageTemplates[NotEmpty::IS_EMPTY],
+        ], $messages, $message . ' missing NotEmpty::IS_EMPTY key and/or contains additional messages');
     }
 
     public function testConstructorRequiresAName()


### PR DESCRIPTION
Per #28, since 2.4, we've not been returning error messages in the expected format when a value is required but no value (or an empty value) was provided for the input.

This patch builds on #60, and update the test expectations to those reported in #28.