### PR TITLE
Feature/required validator

### DIFF
--- a/src/ArrayInput.php
+++ b/src/ArrayInput.php
@@ -63,6 +63,7 @@ class ArrayInput extends Input
         $hasValue = $this->hasValue();
         $required = $this->isRequired();
         $hasFallback = $this->hasFallback();
+        $values    = $this->getValue();
 
         if (! $hasValue && $hasFallback) {
             $this->setValue($this->getFallbackValue());
@@ -70,17 +71,14 @@ class ArrayInput extends Input
         }
 
         if (! $hasValue && $required) {
-            if ($this->errorMessage === null) {
-                $this->errorMessage = $this->prepareRequiredValidationFailureMessage();
-            }
-            return false;
+            $this->injectRequiredValidator();
+            $values = [$this];
         }
 
         if (!$this->continueIfEmpty() && !$this->allowEmpty()) {
             $this->injectNotEmptyValidator();
         }
         $validator = $this->getValidatorChain();
-        $values    = $this->getValue();
         $result    = true;
         foreach ($values as $value) {
             $empty = ($value === null || $value === '' || $value === []);

--- a/src/FileInput.php
+++ b/src/FileInput.php
@@ -118,16 +118,15 @@ class FileInput extends Input
         $required        = $this->isRequired();
         $allowEmpty      = $this->allowEmpty();
         $continueIfEmpty = $this->continueIfEmpty();
+        $validator = $this->getValidatorChain();
 
         if (! $hasValue && ! $required) {
             return true;
         }
 
         if (! $hasValue && $required && ! $this->hasFallback()) {
-            if ($this->errorMessage === null) {
-                $this->errorMessage = $this->prepareRequiredValidationFailureMessage();
-            }
-            return false;
+            $this->injectRequiredValidator();
+            return $validator->isValid($this);
         }
 
         if ($empty && ! $required && ! $continueIfEmpty) {
@@ -139,7 +138,6 @@ class FileInput extends Input
         }
 
         $this->injectUploadValidator();
-        $validator = $this->getValidatorChain();
         //$value   = $this->getValue(); // Do not run the filters yet for File uploads (see getValue())
 
         if (!is_array($rawValue)) {

--- a/src/Validator/Required.php
+++ b/src/Validator/Required.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Zend\InputFilter\Validator;
+
+use Zend\InputFilter\Input;
+use Zend\Validator\AbstractValidator;
+
+class Required extends AbstractValidator
+{
+    const INVALID = 'inputInvalid';
+    const REQUIRED = 'inputRequired';
+
+    /**
+     * @var string[]
+     */
+    protected $messageTemplates = [
+        self::INVALID => 'Invalid type given. Zend\InputFilter\Input is required',
+        self::REQUIRED => 'Value is required',
+    ];
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isValid($value)
+    {
+        if (!($value instanceof Input)) {
+            $this->error(self::INVALID);
+            return false;
+        }
+
+        $input = $value;
+
+        if ($input->hasValue()) { // If has value then all is ok
+            return true;
+        }
+
+        if ($input->isRequired()) { // It's Required and value was not set.
+            $this->error(self::REQUIRED);
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/test/InputTest.php
+++ b/test/InputTest.php
@@ -34,21 +34,6 @@ class InputTest extends TestCase
         $this->input = new Input('foo');
     }
 
-    public function assertRequiredValidationErrorMessage(Input $input, $message = '')
-    {
-        $message  = $message ?: 'Expected failure message for required input';
-        $message .= ';';
-
-        $messages = $input->getMessages();
-        $this->assertInternalType('array', $messages, $message . ' non-array messages array');
-
-        $notEmpty         = new NotEmptyValidator();
-        $messageTemplates = $notEmpty->getOption('messageTemplates');
-        $this->assertSame([
-            NotEmptyValidator::IS_EMPTY => $messageTemplates[NotEmptyValidator::IS_EMPTY],
-        ], $messages, $message . ' missing NotEmpty::IS_EMPTY key and/or contains additional messages');
-    }
-
     public function testConstructorRequiresAName()
     {
         $this->assertEquals('foo', $this->input->getName());
@@ -183,59 +168,28 @@ class InputTest extends TestCase
         $input = $this->input;
         $input->setRequired(true);
 
-        $this->assertFalse(
-            $input->isValid(),
-            'isValid() should be return always false when no fallback value, is required, and not data is set.'
-        );
-        $this->assertRequiredValidationErrorMessage($input);
-    }
-
-    public function testRequiredWithoutFallbackAndValueNotSetThenFailReturnsCustomErrorMessageWhenSet()
-    {
-        $input = $this->input;
-        $input->setRequired(true);
-        $input->setErrorMessage('FAILED TO VALIDATE');
+        $expectedMessages = [
+            'inputRequired' => 'Value is required',
+        ];
 
         $this->assertFalse(
             $input->isValid(),
             'isValid() should be return always false when no fallback value, is required, and not data is set.'
         );
-        $this->assertSame(['FAILED TO VALIDATE'], $input->getMessages());
+        $this->assertEquals($expectedMessages, $input->getMessages(), 'getMessages() value not match');
     }
 
-    /**
-     * @group 28
-     * @group 60
-     */
-    public function testRequiredWithoutFallbackAndValueNotSetProvidesNotEmptyValidatorIsEmptyErrorMessage()
+    public function testRequiredWithoutFallbackAndValueNotSetThenFailWithCustomErrorMessage()
     {
         $input = $this->input;
         $input->setRequired(true);
+        $input->setErrorMessage('fooErrorMessage');
 
         $this->assertFalse(
             $input->isValid(),
-            'isValid() should always return false when no fallback value is present, '
-            . 'the input is required, and no data is set.'
+            'isValid() should be return always false when no fallback value, is required, and not data is set.'
         );
-        $this->assertRequiredValidationErrorMessage($input);
-    }
-
-    /**
-     * @group 28
-     * @group 60
-     */
-    public function testRequiredWithoutFallbackAndValueNotSetProvidesCustomErrorMessageWhenSet()
-    {
-        $input = $this->input;
-        $input->setRequired(true);
-        $input->setErrorMessage('FAILED TO VALIDATE');
-
-        $this->assertFalse(
-            $input->isValid(),
-            'isValid() should always return false when no fallback value is present, '
-            . 'the input is required, and no data is set.'
-        );
-        $this->assertSame(['FAILED TO VALIDATE'], $input->getMessages());
+        $this->assertEquals(['fooErrorMessage'], $input->getMessages(), 'getMessages() value not match');
     }
 
     public function testNotRequiredWithoutFallbackAndValueNotSetThenIsValid()

--- a/test/Validator/RequiredTest.php
+++ b/test/Validator/RequiredTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace ZendTest\InputFilter\Validator;
+
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\InputFilter\Input;
+use Zend\InputFilter\Validator\Required;
+
+/**
+ * @covers Zend\InputFilter\Validator\Required
+ */
+class RequiredTest extends TestCase
+{
+    /**
+     * @var Required
+     */
+    protected $validator;
+
+    protected function setUp()
+    {
+        $this->validator = new Required();
+    }
+
+    /**
+     * @dataProvider inputProvider
+     */
+    public function testValid($input, $expectedIsValid, $expectedMessages)
+    {
+        $this->assertEquals(
+            $expectedIsValid,
+            $this->validator->isValid($input),
+            'isValid() value not match. Detail: ' . json_encode($this->validator->getMessages())
+        );
+
+        $this->assertEquals(
+            $expectedMessages,
+            $this->validator->getMessages(),
+            'getMessages() value not match.'
+        );
+    }
+
+    public function inputProvider()
+    {
+        $requiredMsg = [
+            Required::REQUIRED => 'Value is required',
+        ];
+        $invalidMsg = [
+            Required::INVALID => 'Invalid type given. Zend\InputFilter\Input is required',
+        ];
+
+        $required = true;
+        $hasValue = true;
+
+        // @codingStandardsIgnoreStart
+        return [
+            // Description => [$input, isValid, getMessages]
+            'Invalid type'                => [new \stdClass()                               , false, $invalidMsg],
+            'Required: T. Value: Set'     => [$this->createInputMock($required,   $hasValue), true , []],
+            'Required: T. Value: Not set' => [$this->createInputMock($required,  !$hasValue), false, $requiredMsg],
+            'Required: F. Value: set'     => [$this->createInputMock(!$required,  $hasValue), true , []],
+            'Required: F. Value: Not set' => [$this->createInputMock(!$required, !$hasValue), true , []],
+        ];
+        // @codingStandardsIgnoreEnd
+    }
+
+    /**
+     * @param bool $required
+     * @param bool $hasValue
+     *
+     * @return Input|MockObject
+     */
+    protected function createInputMock($required, $hasValue)
+    {
+        /** @var Input|MockObject $input */
+        $input = $this->getMock(Input::class);
+
+        $input->method('isRequired')
+            ->willReturn($required)
+        ;
+
+        $input->method('hasValue')
+            ->willReturn($hasValue)
+        ;
+
+        return $input;
+    }
+}


### PR DESCRIPTION
These allows manage the required message like any other ValidatorInterface element.

Note: While you can add the validator manually the flag `setRequired` must be set too

``` php
  $input = new Input();
  $input->setRequired(true);empty value instead *not set*.
  $input->getValidatorChain()->attach(
      new Zend\InputFilter\Validator\Required(),
      true                             // break chain on failure

  );
```

``` php
  $inputSpecification = [
    'required'   => true,
    'validators' => [
      [
        'break_chain_on_failure' => true,
        'name'                   => 'Zend\\InputFilter\\Validator\\Required',
      ],
    ],
  ];
```

Note: `setRequired(false)` may not be enough and you will need remove the validator from the chain.
