### PR TITLE
[Travis] Add vendor dir to cache 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ branches:
 cache:
   directories:
     - $HOME/.composer/cache
+    - vendor
 
 matrix:
   fast_finish: true
@@ -36,6 +37,7 @@ before_install:
 
 install:
   - travis_retry composer install --no-interaction --ignore-platform-reqs
+  - composer info -i
 
 script:
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then ./vendor/bin/phpunit --coverage-clover clover.xml ; fi


### PR DESCRIPTION
It's most faster than copy the files from Composer's cache to vendor dir.

The speedup can be seen when XDebug is enabled (currently PHP 5.6 run) The copy of files is reduced to halt. Or may it's due the clone of php-coveralls dependency