### PR TITLE
Fix #28 - NotEmpty validation message cannot be localized

### DIFF
--- a/src/Input.php
+++ b/src/Input.php
@@ -491,10 +491,17 @@ class Input implements
      */
     protected function prepareRequiredValidationFailureMessage()
     {
-        $notEmpty = new NotEmpty();
-        $templates = $notEmpty->getOption('messageTemplates');
+        $notEmpty   = new NotEmpty();
+        $templates  = $notEmpty->getOption('messageTemplates');
+        $message    = $templates[NotEmpty::IS_EMPTY];
+        $translator = $notEmpty->getTranslator();
+
+        if ($translator) {
+            $message = $translator->translate($message, $notEmpty->getTranslatorTextDomain());
+        }
+
         return [
-            NotEmpty::IS_EMPTY => $templates[NotEmpty::IS_EMPTY],
+            NotEmpty::IS_EMPTY => $message,
         ];
     }
 }

--- a/src/Input.php
+++ b/src/Input.php
@@ -491,7 +491,7 @@ class Input implements
      */
     protected function prepareRequiredValidationFailureMessage()
     {
-        $notEmpty   = new NotEmpty();
+        $notEmpty   = $this->getValidatorChain()->plugin(NotEmpty::class);
         $templates  = $notEmpty->getOption('messageTemplates');
         $message    = $templates[NotEmpty::IS_EMPTY];
         $translator = $notEmpty->getTranslator();


### PR DESCRIPTION
even after #60, #61 and #63, issue #28 was still reproducible.

Related:
* #28
* #60 
* #61 
* #63 
* #64 
* #67 
* #69 
* #73
* #94
