### PR TITLE
Patch for integer indexed nested InputFilters defined in input_filter_specs

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -343,9 +343,12 @@ class Factory
                 // Patch to enable nested, integer indexed input_filter_specs
                 // InputFilter doesn't have an name property!
                 // But if the key is an integer and type and name are specified maybe we could use it.
-                if (is_integer($key) && isset($value['type']) && is_string($value['type'])) {
+                if (isset($value['type']) && is_string($value['type'])) {
                     if (isset($value['name']) && is_string($value['name'])) {
-                        $key = $value['name'];
+                        if (is_integer($key)) {
+                            $key = $value['name'];
+                        }
+                        // Remove
                         unset($value['name']);
                     }
                 }

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -307,12 +307,12 @@ class Factory
         }
 
         $type = InputFilter::class;
-    
+
         if (isset($inputFilterSpecification['type']) && is_string($inputFilterSpecification['type'])) {
             $type = $inputFilterSpecification['type'];
             unset($inputFilterSpecification['type']);
         }
-        
+
         $inputFilter = $this->getInputFilterManager()->get($type);
 
         if ($inputFilter instanceof CollectionInputFilter) {
@@ -339,9 +339,9 @@ class Factory
             ) {
                 $input = $value;
             } else {
-                
+
                 // Patch to enable nested, integer indexed input_filter_specs
-                // InputFilter doesn't have an name property! 
+                // InputFilter doesn't have an name property!
                 // But if the key is an integer and type and name are specified maybe we could use it.
                 if (is_integer($key) && isset($value['type']) && is_string($value['type'])) {
                     if (isset($value['name']) && is_string($value['name'])) {
@@ -349,7 +349,7 @@ class Factory
                         unset($value['name']);
                     }
                 }
-                
+
                 $input = $this->createInput($value);
             }
 

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -341,14 +341,17 @@ class Factory
             } else {
 
                 // Patch to enable nested, integer indexed input_filter_specs
-                // InputFilter doesn't have an name property!
-                // But if the key is an integer and type and name are specified maybe we could use it.
-                if (isset($value['type']) && is_string($value['type'])) {
-                    if (isset($value['name']) && is_string($value['name'])) {
+                // Check type and name are in spec
+                if (isset($value['type']) && is_string($value['type'])
+                    && isset($value['name']) && is_string($value['name'])) {
+                    // Make sure type is an InputFilter
+                    $checkType = $this->getInputFilterManager()->get($value['type']);
+                    if ($checkType instanceof InputFilter) {
+                        // Only apply when key is an integer
                         if (is_integer($key)) {
                             $key = $value['name'];
                         }
-                        // Remove
+                        // Remove name from spec. InputFilter doesn't have an name property!
                         unset($value['name']);
                     }
                 }

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -307,12 +307,12 @@ class Factory
         }
 
         $type = InputFilter::class;
-
+    
         if (isset($inputFilterSpecification['type']) && is_string($inputFilterSpecification['type'])) {
             $type = $inputFilterSpecification['type'];
             unset($inputFilterSpecification['type']);
         }
-
+        
         $inputFilter = $this->getInputFilterManager()->get($type);
 
         if ($inputFilter instanceof CollectionInputFilter) {
@@ -339,6 +339,17 @@ class Factory
             ) {
                 $input = $value;
             } else {
+                
+                // Patch to enable nested, integer indexed input_filter_specs
+                // InputFilter doesn't have an name property! 
+                // But if the key is an integer and type and name are specified maybe we could use it.
+                if (is_integer($key) && isset($value['type']) && is_string($value['type'])) {
+                    if (isset($value['name']) && is_string($value['name'])) {
+                        $key = $value['name'];
+                        unset($value['name']);
+                    }
+                }
+                
                 $input = $this->createInput($value);
             }
 

--- a/test/FactoryTest.php
+++ b/test/FactoryTest.php
@@ -918,18 +918,20 @@ class FactoryTest extends TestCase
         $factory = $this->createDefaultFactory();
         $inputFilter = $factory->createInputFilter([
             1 => [
+                'type' => InputFilter::class,
                 'name' => 'foo',
             ],
         ]);
 
         $this->assertTrue($inputFilter->has('foo'));
     }
-    
+
     public function testCreateInputFilterUsesAssociatedNameMappingOverConfiguredName()
     {
         $factory = $this->createDefaultFactory();
         $inputFilter = $factory->createInputFilter([
             'foo' => [
+                'type' => InputFilter::class,
                 'name' => 'bar',
             ],
         ]);
@@ -937,7 +939,7 @@ class FactoryTest extends TestCase
         $this->assertTrue($inputFilter->has('foo'));
         $this->assertFalse($inputFilter->has('bar'));
     }
-    
+
     public function testCreateInputFilterUsesConfiguredNameForNestedInputFilters()
     {
         $factory = $this->createDefaultFactory();
@@ -979,7 +981,7 @@ class FactoryTest extends TestCase
         $this->assertEquals(1, count($collectionInputFilter));
         $this->assertTrue($collectionInputFilter->has('bat'));
     }
-    
+
     /**
      * @return Factory
      */

--- a/test/FactoryTest.php
+++ b/test/FactoryTest.php
@@ -913,6 +913,73 @@ class FactoryTest extends TestCase
         $this->assertSame('bar', $input->getName());
     }
 
+    public function testCreateInputFilterConfiguredNameWhenSpecIsIntegerIndexed()
+    {
+        $factory = $this->createDefaultFactory();
+        $inputFilter = $factory->createInputFilter([
+            1 => [
+                'name' => 'foo',
+            ],
+        ]);
+
+        $this->assertTrue($inputFilter->has('foo'));
+    }
+    
+    public function testCreateInputFilterUsesAssociatedNameMappingOverConfiguredName()
+    {
+        $factory = $this->createDefaultFactory();
+        $inputFilter = $factory->createInputFilter([
+            'foo' => [
+                'name' => 'bar',
+            ],
+        ]);
+
+        $this->assertTrue($inputFilter->has('foo'));
+        $this->assertFalse($inputFilter->has('bar'));
+    }
+    
+    public function testCreateInputFilterUsesConfiguredNameForNestedInputFilters()
+    {
+        $factory = $this->createDefaultFactory();
+        $inputFilter = $factory->createInputFilter([
+            0 => [
+                'type' => InputFilter::class,
+                'name' => 'bar',
+                '0' => [
+                    'name' => 'bat',
+                ],
+                '1' => [
+                    'name' => 'baz',
+                ],
+            ],
+            1 => [
+                'type' => CollectionInputFilter::class,
+                'name' => 'foo',
+                'input_filter' => [
+                    '0' => [
+                        'name' => 'bat',
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertInstanceOf(InputFilter::class, $inputFilter);
+        $this->assertEquals(2, count($inputFilter));
+
+        $nestedInputFilter = $inputFilter->get('bar');
+        $this->assertInstanceOf(InputFilter::class, $nestedInputFilter);
+        $this->assertEquals(2, count($nestedInputFilter));
+        $this->assertTrue($nestedInputFilter->has('bat'));
+        $this->assertTrue($nestedInputFilter->has('baz'));
+
+        $collection = $inputFilter->get('foo');
+        $this->assertInstanceOf(CollectionInputFilter::class, $collection);
+        $collectionInputFilter = $collection->getInputFilter();
+        $this->assertInstanceOf(InputFilter::class, $collectionInputFilter);
+        $this->assertEquals(1, count($collectionInputFilter));
+        $this->assertTrue($collectionInputFilter->has('bat'));
+    }
+    
     /**
      * @return Factory
      */

--- a/test/InputFilterAbstractServiceFactoryTest.php
+++ b/test/InputFilterAbstractServiceFactoryTest.php
@@ -13,7 +13,6 @@ namespace ZendTest\InputFilter;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Filter\FilterPluginManager;
-use Zend\InputFilter\CollectionInputFilter;
 use Zend\InputFilter\InputFilterAbstractServiceFactory;
 use Zend\InputFilter\InputFilterInterface;
 use Zend\InputFilter\InputFilterPluginManager;

--- a/test/InputFilterAbstractServiceFactoryTest.php
+++ b/test/InputFilterAbstractServiceFactoryTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Zend Framework (http://framework.zend.com/)
  *
@@ -12,6 +13,7 @@ namespace ZendTest\InputFilter;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Filter\FilterPluginManager;
+use Zend\InputFilter\CollectionInputFilter;
 use Zend\InputFilter\InputFilterAbstractServiceFactory;
 use Zend\InputFilter\InputFilterInterface;
 use Zend\InputFilter\InputFilterPluginManager;
@@ -24,6 +26,7 @@ use Zend\Validator\ValidatorPluginManager;
  */
 class InputFilterAbstractServiceFactoryTest extends TestCase
 {
+
     /** @var ServiceManager */
     protected $services;
 


### PR DESCRIPTION
Apigiltiy uses integer indexed arrays and nested `input_filter_specs` only work with associative arrays!

In Apigility I have a code-connected resource with an embedded collection of items. For validation I defined an `input_filter_spec` with a nested `CollectionInputFilter` using associative arrays. 
Problems started when I manually defined this filter in `zf-content-validation` for the resource. At first integration worked perfect except there where no fields visible in Apigility but the filter worked incl. the embedded items. But when I added a field it removed all the `input_filter_specs` of the filter. 
Next I defined my filter using an integer-index and the filter stopped working on the embedded items because the nested input filter has no name property.

This patch tries to solve this by allowing `input_filter_specs` to have a `name` entry.

To minimize side effects or possible BC breaks the name is used only on integer indexed specs with a `type` defined and the name itself is a string.

A side effect of the patch is Apigility shows all fields but silently breaks (Angular exception) when trying to add a filter. Adding a validator works but is faulty. It should not be difficult to prevent Apigility from modifying fields with nested filters. Developers of resources with nested entities will be helped and are already used to do manual changes.