### PR TITLE
BaseInputFilter::populate() calls resetValue() for missing arrayinputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- `ArrayInput::hasValue()` returned `true` for inputs that didn't get a value via `BaseInputFilter::setData()`
 
 ## 2.5.5 - 2015-09-03
 

--- a/src/BaseInputFilter.php
+++ b/src/BaseInputFilter.php
@@ -513,7 +513,7 @@ class BaseInputFilter implements
                 }
 
                 if ($input instanceof ArrayInput) {
-                    $input->setValue([]);
+                    $input->resetValue();
                     continue;
                 }
 

--- a/src/BaseInputFilter.php
+++ b/src/BaseInputFilter.php
@@ -512,11 +512,6 @@ class BaseInputFilter implements
                     continue;
                 }
 
-                if ($input instanceof ArrayInput) {
-                    $input->resetValue();
-                    continue;
-                }
-
                 if ($input instanceof Input) {
                     $input->resetValue();
                     continue;

--- a/test/BaseInputFilterTest.php
+++ b/test/BaseInputFilterTest.php
@@ -565,8 +565,7 @@ class BaseInputFilterTest extends TestCase
         $arrayInput = $this->getMock(ArrayInput::class);
         $arrayInput
             ->expects($this->once())
-            ->method('setValue')
-            ->with([]);
+            ->method('resetValue');
 
         $filter = $this->inputFilter;
         $filter->add($arrayInput, 'arrayInput');
@@ -596,6 +595,15 @@ class BaseInputFilterTest extends TestCase
             ],
             array_keys($inputFilter->getInputs())
         );
+    }
+
+    public function testHasValueIsFalseIfNoValueWasProvided()
+    {
+        $inputFilter = new BaseInputFilter();
+        $inputFilter->add(new ArrayInput(), 'foo');
+
+        $inputFilter->setData([]);
+        $this->assertFalse($inputFilter->get('foo')->hasValue());
     }
 
     public function addMethodArgumentsProvider()


### PR DESCRIPTION
`hasValue` returns true for ArrayInputs whether or not a value was provided via `InputFilter::setData()`. This can't be the expected behavior of this function.

However, i had to refactor the existing test `BaseInputFilterTest::testPopulateSupportsArrayInputEvenIfDataMissing`. I don't know the implications regarding BC because neither the docblock nor the commit message provided a useful use-case for this test-method.

Feedback is very welcome.

Thank you for considering my pull request.