### PR TITLE
Hotfix/69

### DIFF
--- a/src/Input.php
+++ b/src/Input.php
@@ -491,7 +491,20 @@ class Input implements
      */
     protected function prepareRequiredValidationFailureMessage()
     {
-        $notEmpty = new NotEmpty();
+        $chain = $this->getValidatorChain();
+        $validators = $chain->getValidators();
+
+        foreach ($validators as $validator) {
+            if ($validator['instance'] instanceof NotEmpty) {
+                $notEmpty = $validator['instance'];
+                break;
+            }
+        }
+
+        if (!isset($notEmpty)) {
+            $notEmpty = new NotEmpty();
+        }
+
         $templates = $notEmpty->getOption('messageTemplates');
         return [
             NotEmpty::IS_EMPTY => $templates[NotEmpty::IS_EMPTY],

--- a/test/InputTest.php
+++ b/test/InputTest.php
@@ -222,6 +222,39 @@ class InputTest extends TestCase
 
     /**
      * @group 28
+     * @group 69
+     */
+    public function testRequiredWithoutFallbackAndValueNotSetProvidesAttachedNotEmptyValidatorIsEmptyErrorMessage()
+    {
+        $input = new Input();
+        $input->setRequired(true);
+
+        $customMessage = [
+            NotEmptyValidator::IS_EMPTY => "Custom message",
+        ];
+
+        $notEmpty = $this->getMockBuilder(NotEmptyValidator::class)
+            ->setMethods(['getOption'])
+            ->getMock();
+
+        $notEmpty->expects($this->once())
+            ->method('getOption')
+            ->with('messageTemplates')
+            ->willReturn($customMessage);
+
+        $input->getValidatorChain()
+            ->attach($notEmpty);
+
+        $this->assertFalse(
+            $input->isValid(),
+            'isValid() should always return false when no fallback value is present, '
+            . 'the input is required, and no data is set.'
+        );
+        $this->assertEquals($customMessage, $input->getMessages());
+    }
+
+    /**
+     * @group 28
      * @group 60
      */
     public function testRequiredWithoutFallbackAndValueNotSetProvidesCustomErrorMessageWhenSet()


### PR DESCRIPTION
This fixes #69 and also touches #28. Basically it uses the message of an existing `NotEmpty` validator instead of creating a new `NotEmpty` validator when a required input is missing.