### PR TITLE
pass configured input filter plugin manager to generated input filter factories

### DIFF
--- a/src/InputFilterAbstractServiceFactory.php
+++ b/src/InputFilterAbstractServiceFactory.php
@@ -81,6 +81,10 @@ class InputFilterAbstractServiceFactory implements AbstractFactoryInterface
             ->getDefaultValidatorChain()
             ->setPluginManager($this->getValidatorPluginManager($services));
 
+        if ($services->has('FilterManager') && $services->has('ValidatorManager')) {
+            $this->factory->setInputFilterManager($this->getInputFilterPluginManager($services));
+        }
+
         return $this->factory;
     }
 
@@ -108,5 +112,18 @@ class InputFilterAbstractServiceFactory implements AbstractFactoryInterface
         }
 
         return new ValidatorPluginManager();
+    }
+
+    /**
+     * @param ServiceLocatorInterface $services
+     * @return InputFilterPluginManager
+     */
+    protected function getInputFilterPluginManager(ServiceLocatorInterface $services)
+    {
+        if ($services->has('InputFilterManager')) {
+            return $services->get('InputFilterManager');
+        }
+
+        return new InputFilterPluginManager();
     }
 }


### PR DESCRIPTION
pass configured input filter plugin manager to generated input filter factories to allow for complex input filter nesting. this enables reuse of named input filter services within nested input filter contexts.

i added more logic in the factory than i had originally intended, in order to preserve backwards compatibility.