### PR TITLE
Finalize zend-servicemanager forwards-compatibility changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ matrix:
     - php: 5.5
       env:
         - EXECUTE_CS_CHECK=true
+        - SERVICE_MANAGER_V2=true
     - php: 5.6
       env:
         - EXECUTE_TEST_COVERALLS=true
@@ -35,7 +36,8 @@ before_install:
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
 
 install:
-  - travis_retry composer install --no-interaction --ignore-platform-reqs
+  - if [[ $SERVICE_MANAGER_V2 != 'true' ]]; then travis_retry composer install --no-interaction --ignore-platform-reqs ; fi
+  - if [[ $SERVICE_MANAGER_V2 == 'true' ]]; then travis_retry composer update --no-interaction --ignore-platform-reqs --prefer-lowest ; fi
 
 script:
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then ./vendor/bin/phpunit --coverage-clover clover.xml ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,23 @@ matrix:
     - php: 5.5
       env:
         - EXECUTE_CS_CHECK=true
-        - SERVICE_MANAGER_V2=true
+    - php: 5.5
+      env:
+        - SERVICE_MANAGER_VERSION="^2.7.5"
     - php: 5.6
       env:
         - EXECUTE_TEST_COVERALLS=true
+    - php: 5.6
+      env:
+        - SERVICE_MANAGER_VERSION="^2.7.5"
     - php: 7
-    - php: hhvm 
+    - php: 7
+      env:
+        - SERVICE_MANAGER_VERSION="^2.7.5"
+    - php: hhvm
+    - php: hhvm
+      env:
+        - SERVICE_MANAGER_VERSION="^2.7.5"
   allow_failures:
     - php: 7
 
@@ -34,6 +45,8 @@ before_install:
   - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
   - composer self-update
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
+  - if [[ $SERVICE_MANAGER_VERSION != '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:$SERVICE_MANAGER_VERSION" ; fi
+  - if [[ $SERVICE_MANAGER_VERSION == '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^3.0.3" ; fi
 
 install:
   - if [[ $SERVICE_MANAGER_V2 != 'true' ]]; then travis_retry composer install --no-interaction --ignore-platform-reqs ; fi

--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,9 @@
         }
     },
     "require": {
-        "php": ">=5.5",
-        "zendframework/zend-filter": "^2.6.0",
-        "zendframework/zend-validator": "^2.6.0",
+        "php": "^5.5 || ^7.0",
+        "zendframework/zend-filter": "^2.6",
+        "zendframework/zend-validator": "^2.6",
         "zendframework/zend-stdlib": "^2.7 || ^3.0"
     },
     "require-dev": {
@@ -40,4 +40,3 @@
         }
     }
 }
-

--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,12 @@
     },
     "require": {
         "php": ">=5.5",
-        "zendframework/zend-filter": "~2.5",
-        "zendframework/zend-validator": "^2.5.3",
-        "zendframework/zend-stdlib": "~2.5"
+        "zendframework/zend-filter": "^2.6.0",
+        "zendframework/zend-validator": "^2.6.0",
+        "zendframework/zend-stdlib": "^2.7 || ^3.0"
     },
     "require-dev": {
-        "zendframework/zend-servicemanager": "~2.5",
+        "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "^4.5"
     },
@@ -40,3 +40,4 @@
         }
     }
 }
+

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -11,7 +11,7 @@ namespace Zend\InputFilter;
 
 use Traversable;
 use Zend\Filter\FilterChain;
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Zend\ServiceManager\ServiceManager;
 use Zend\Stdlib\ArrayUtils;
 use Zend\Validator\ValidatorChain;
 use Zend\Validator\ValidatorInterface;
@@ -117,15 +117,7 @@ class Factory
     public function setInputFilterManager(InputFilterPluginManager $inputFilterManager)
     {
         $this->inputFilterManager = $inputFilterManager;
-        $serviceLocator = $this->inputFilterManager->getServiceLocator();
-        if ($serviceLocator && $serviceLocator instanceof ServiceLocatorInterface) {
-            if ($serviceLocator->has('ValidatorManager')) {
-                $this->getDefaultValidatorChain()->setPluginManager($serviceLocator->get('ValidatorManager'));
-            }
-            if ($serviceLocator->has('FilterManager')) {
-                $this->getDefaultFilterChain()->setPluginManager($serviceLocator->get('FilterManager'));
-            }
-        }
+        $inputFilterManager->populateFactoryPluginManagers($this);
         return $this;
     }
 
@@ -135,7 +127,7 @@ class Factory
     public function getInputFilterManager()
     {
         if (null === $this->inputFilterManager) {
-            $this->inputFilterManager = new InputFilterPluginManager;
+            $this->inputFilterManager = new InputFilterPluginManager(new ServiceManager());
         }
 
         return $this->inputFilterManager;

--- a/src/InputFilterPluginManager.php
+++ b/src/InputFilterPluginManager.php
@@ -95,19 +95,22 @@ class InputFilterPluginManager extends AbstractPluginManager
         }
     }
 
+    /**
+     * Populate the filter and validator managers for the default filter/validator chains.
+     *
+     * @param Factory $factory
+     * @return void
+     */
     public function populateFactoryPluginManagers(Factory $factory)
     {
-        if (property_exists($this, 'creationContext')) {
-            // v3
-            $container = $this->creationContext;
-        } else {
-            // v2
-            $container = $this->serviceLocator;
-        }
+        $container = property_exists($this, 'creationContext')
+            ? $this->creationContext // v3
+            : $this->serviceLocator; // v2
 
         if ($container && $container->has('FilterManager')) {
             $factory->getDefaultFilterChain()->setPluginManager($container->get('FilterManager'));
         }
+
         if ($container && $container->has('ValidatorManager')) {
             $factory->getDefaultValidatorChain()->setPluginManager($container->get('ValidatorManager'));
         }

--- a/src/InputFilterPluginManager.php
+++ b/src/InputFilterPluginManager.php
@@ -158,9 +158,4 @@ class InputFilterPluginManager extends AbstractPluginManager
             throw new Exception\RuntimeException($e->getMessage(), $e->getCode(), $e);
         }
     }
-
-    public function shareByDefault()
-    {
-        return $this->sharedByDefault;
-    }
 }

--- a/src/InputFilterPluginManager.php
+++ b/src/InputFilterPluginManager.php
@@ -9,9 +9,10 @@
 
 namespace Zend\InputFilter;
 
+use Interop\Container\ContainerInterface;
 use Zend\ServiceManager\AbstractPluginManager;
-use Zend\ServiceManager\ConfigInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Zend\ServiceManager\Exception\InvalidServiceException;
+use Zend\ServiceManager\Factory\InvokableFactory;
 use Zend\Stdlib\InitializableInterface;
 
 /**
@@ -22,55 +23,100 @@ use Zend\Stdlib\InitializableInterface;
 class InputFilterPluginManager extends AbstractPluginManager
 {
     /**
+     * Default alias of plugins
+     *
+     * @var string[]
+     */
+    protected $aliases = [
+        'inputfilter' => InputFilter::class,
+        'inputFilter' => InputFilter::class,
+        'InputFilter' => InputFilter::class,
+        'collection'  => CollectionInputFilter::class,
+        'Collection'  => CollectionInputFilter::class,
+    ];
+
+    /**
      * Default set of plugins
      *
      * @var string[]
      */
-    protected $invokableClasses = [
-        'inputfilter' => InputFilter::class,
-        'collection'  => CollectionInputFilter::class,
+    protected $factories = [
+        InputFilter::class                      => InvokableFactory::class,
+        CollectionInputFilter::class            => InvokableFactory::class,
+        // v2 canonical FQCN
+        'zendinputfilterinputfilter'            => InvokableFactory::class,
+        'zendinputfiltercollectioninputfilter'  => InvokableFactory::class,
     ];
 
     /**
-     * Whether or not to share by default
+     * Whether or not to share by default (v3)
+     *
+     * @var bool
+     */
+    protected $sharedByDefault = false;
+
+    /**
+     * Whether or not to share by default (v2)
      *
      * @var bool
      */
     protected $shareByDefault = false;
 
-    /**
-     * @param ConfigInterface $configuration
-     */
-    public function __construct(ConfigInterface $configuration = null)
-    {
-        parent::__construct($configuration);
 
+    /**
+     * @param ContainerInterface $parentLocator
+     * @param array $config
+     */
+    public function __construct(ContainerInterface $parentLocator, array $config = [])
+    {
+        parent::__construct($parentLocator, $config);
         $this->addInitializer([$this, 'populateFactory']);
     }
 
     /**
      * Inject this and populate the factory with filter chain and validator chain
      *
-     * @param $inputFilter
+     * @param mixed $first
+     * @param mixed $second
      */
-    public function populateFactory($inputFilter)
+    public function populateFactory($first, $second)
     {
+        if ($first instanceof ContainerInterface) {
+            $container = $first;
+            $inputFilter = $second;
+        } else {
+            $container = $second;
+            $inputFilter = $first;
+        }
         if ($inputFilter instanceof InputFilter) {
             $factory = $inputFilter->getFactory();
 
             $factory->setInputFilterManager($this);
+        }
+    }
 
-            if ($this->serviceLocator instanceof ServiceLocatorInterface) {
-                $factory->getDefaultFilterChain()->setPluginManager($this->serviceLocator->get('FilterManager'));
-                $factory->getDefaultValidatorChain()->setPluginManager($this->serviceLocator->get('ValidatorManager'));
-            }
+    public function populateFactoryPluginManagers(Factory $factory)
+    {
+        if (property_exists($this, 'creationContext')) {
+            // v3
+            $container = $this->creationContext;
+        } else {
+            // v2
+            $container = $this->serviceLocator;
+        }
+
+        if ($container && $container->has('FilterManager')) {
+            $factory->getDefaultFilterChain()->setPluginManager($container->get('FilterManager'));
+        }
+        if ($container && $container->has('ValidatorManager')) {
+            $factory->getDefaultValidatorChain()->setPluginManager($container->get('ValidatorManager'));
         }
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc} (v3)
      */
-    public function validatePlugin($plugin)
+    public function validate($plugin)
     {
         if ($plugin instanceof InputFilterInterface || $plugin instanceof InputInterface) {
             // Hook to perform various initialization, when the inputFilter is not created through the factory
@@ -82,11 +128,35 @@ class InputFilterPluginManager extends AbstractPluginManager
             return;
         }
 
-        throw new Exception\RuntimeException(sprintf(
+        throw new InvalidServiceException(sprintf(
             'Plugin of type %s is invalid; must implement %s or %s',
             (is_object($plugin) ? get_class($plugin) : gettype($plugin)),
             InputFilterInterface::class,
             InputInterface::class
         ));
+    }
+
+    /**
+     * Validate the plugin (v2)
+     *
+     * Checks that the filter loaded is either a valid callback or an instance
+     * of FilterInterface.
+     *
+     * @param  mixed                      $plugin
+     * @return void
+     * @throws Exception\RuntimeException if invalid
+     */
+    public function validatePlugin($plugin)
+    {
+        try {
+            $this->validate($plugin);
+        } catch (InvalidServiceException $e) {
+            throw new Exception\RuntimeException($e->getMessage(), $e->getCode(), $e);
+        }
+    }
+
+    public function shareByDefault()
+    {
+        return $this->sharedByDefault;
     }
 }

--- a/src/InputFilterPluginManager.php
+++ b/src/InputFilterPluginManager.php
@@ -62,15 +62,16 @@ class InputFilterPluginManager extends AbstractPluginManager
      */
     protected $shareByDefault = false;
 
-
     /**
-     * @param ContainerInterface $parentLocator
-     * @param array $config
+     * @param null|\Zend\ServiceManager\ConfigInterface|ContainerInterface $configOrContainer
+     *     For zend-servicemanager v2, null or a ConfigInterface instance are
+     *     allowed; for v3, a ContainerInterface is expected.
+     * @param array $v3config Optional configuration array (zend-servicemanager v3 only)
      */
-    public function __construct(ContainerInterface $parentLocator, array $config = [])
+    public function __construct($configOrContainer = null, array $v3config = [])
     {
-        parent::__construct($parentLocator, $config);
-        $this->addInitializer([$this, 'populateFactory']);
+        $this->initializers[] = [$this, 'populateFactory'];
+        parent::__construct($configOrContainer, $v3config);
     }
 
     /**

--- a/test/FactoryTest.php
+++ b/test/FactoryTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\InputFilter;
 
+use Interop\Container\ContainerInterface;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Filter;
@@ -45,17 +46,17 @@ class FactoryTest extends TestCase
 
     public function testCreateInputWithTypeAsAnUnknownPluginAndNotExistsAsClassNameThrowException()
     {
-        $factory = $this->createDefaultFactory();
         $type = 'foo';
-
         /** @var InputFilterPluginManager|MockObject $pluginManager */
-        $pluginManager = $this->getMock(InputFilterPluginManager::class);
+        $pluginManager = $this->getMockBuilder(InputFilterPluginManager::class)
+            ->disableOriginalConstructor()
+            ->getMock();
         $pluginManager->expects($this->atLeastOnce())
             ->method('has')
             ->with($type)
-            ->willReturn(false)
-        ;
-        $factory->setInputFilterManager($pluginManager);
+            ->willReturn(false);
+
+        $factory = new Factory($pluginManager);
 
         $this->setExpectedException(
             RuntimeException::class,
@@ -68,13 +69,30 @@ class FactoryTest extends TestCase
         );
     }
 
+    public function testGetInputFilterManagerSettedByItsSetter()
+    {
+        $pluginManager = $this->getMockBuilder(InputFilterPluginManager::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $factory = new Factory();
+        $factory->setInputFilterManager($pluginManager);
+        $this->assertSame($pluginManager, $factory->getInputFilterManager());
+    }
+
+    public function testGetInputFilterManagerWhenYouConstructFactoryWithIt()
+    {
+        $pluginManager = $this->getMockBuilder(InputFilterPluginManager::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $factory = new Factory($pluginManager);
+        $this->assertSame($pluginManager, $factory->getInputFilterManager());
+    }
+
     public function testCreateInputWithTypeAsAnInvalidPluginInstanceThrowException()
     {
-        $factory = $this->createDefaultFactory();
         $type = 'fooPlugin';
         $pluginManager = $this->createInputFilterPluginManagerMockForPlugin($type, 'invalid_value');
-
-        $factory->setInputFilterManager($pluginManager);
+        $factory = new Factory($pluginManager);
 
         $this->setExpectedException(
             RuntimeException::class,
@@ -283,9 +301,11 @@ class FactoryTest extends TestCase
 
     public function testFactoryUsesComposedFilterChainWhenCreatingNewInputObjects()
     {
+        $smMock = $this->getMock(ContainerInterface::class);
+
         $factory       = $this->createDefaultFactory();
         $filterChain   = new Filter\FilterChain();
-        $pluginManager = new Filter\FilterPluginManager();
+        $pluginManager = new Filter\FilterPluginManager($smMock);
         $filterChain->setPluginManager($pluginManager);
         $factory->setDefaultFilterChain($filterChain);
         $input = $factory->createInput([
@@ -299,9 +319,10 @@ class FactoryTest extends TestCase
 
     public function testFactoryUsesComposedValidatorChainWhenCreatingNewInputObjects()
     {
+        $smMock = $this->getMock(ContainerInterface::class);
         $factory          = $this->createDefaultFactory();
         $validatorChain   = new Validator\ValidatorChain();
-        $validatorPlugins = new Validator\ValidatorPluginManager();
+        $validatorPlugins = new Validator\ValidatorPluginManager($smMock);
         $validatorChain->setPluginManager($validatorPlugins);
         $factory->setDefaultValidatorChain($validatorChain);
         $input = $factory->createInput([
@@ -315,9 +336,10 @@ class FactoryTest extends TestCase
 
     public function testFactoryInjectsComposedFilterAndValidatorChainsIntoInputObjectsWhenCreatingNewInputFilterObjects()
     {
+        $smMock = $this->getMock(ContainerInterface::class);
         $factory          = $this->createDefaultFactory();
-        $filterPlugins    = new Filter\FilterPluginManager();
-        $validatorPlugins = new Validator\ValidatorPluginManager();
+        $filterPlugins    = new Filter\FilterPluginManager($smMock);
+        $validatorPlugins = new Validator\ValidatorPluginManager($smMock);
         $filterChain      = new Filter\FilterChain();
         $validatorChain   = new Validator\ValidatorChain();
         $filterChain->setPluginManager($filterPlugins);
@@ -348,11 +370,11 @@ class FactoryTest extends TestCase
             'name'    => 'foo',
             'filters' => [
                 [
-                    'name' => 'string_trim',
+                    'name' => Filter\StringTrim::class
                 ],
                 $htmlEntities,
                 [
-                    'name' => 'string_to_lower',
+                    'name' => Filter\StringToLower::class,
                     'options' => [
                         'encoding' => 'ISO-8859-1',
                     ],
@@ -390,11 +412,11 @@ class FactoryTest extends TestCase
             'name'       => 'foo',
             'validators' => [
                 [
-                    'name' => 'not_empty',
+                    'name' => Validator\NotEmpty::class,
                 ],
                 $digits,
                 [
-                    'name' => 'string_length',
+                    'name' => Validator\StringLength::class,
                     'options' => [
                         'min' => 3,
                         'max' => 5,
@@ -509,10 +531,10 @@ class FactoryTest extends TestCase
                 'required'   => false,
                 'validators' => [
                     [
-                        'name' => 'not_empty',
+                        'name' => Validator\NotEmpty::class,
                     ],
                     [
-                        'name' => 'string_length',
+                        'name' => Validator\StringLength::class,
                         'options' => [
                             'min' => 3,
                             'max' => 5,
@@ -524,10 +546,10 @@ class FactoryTest extends TestCase
                 'allow_empty' => true,
                 'filters'     => [
                     [
-                        'name' => 'string_trim',
+                        'name' => Filter\StringTrim::class,
                     ],
                     [
-                        'name' => 'string_to_lower',
+                        'name' => Filter\StringToLower::class,
                         'options' => [
                             'encoding' => 'ISO-8859-1',
                         ],
@@ -541,10 +563,10 @@ class FactoryTest extends TestCase
                     'required'   => false,
                     'validators' => [
                         [
-                            'name' => 'not_empty',
+                            'name' => Validator\NotEmpty::class,
                         ],
                         [
-                            'name' => 'string_length',
+                            'name' => Validator\StringLength::class,
                             'options' => [
                                 'min' => 3,
                                 'max' => 5,
@@ -556,10 +578,10 @@ class FactoryTest extends TestCase
                     'allow_empty' => true,
                     'filters'     => [
                         [
-                            'name' => 'string_trim',
+                            'name' => Filter\StringTrim::class
                         ],
                         [
-                            'name' => 'string_to_lower',
+                            'name' => Filter\StringToLower::class,
                             'options' => [
                                 'encoding' => 'ISO-8859-1',
                             ],
@@ -689,15 +711,15 @@ class FactoryTest extends TestCase
             'name'    => 'foo',
             'filters' => [
                 [
-                    'name'      => 'string_trim',
+                    'name'      => 'StringTrim',
                     'priority'  => Filter\FilterChain::DEFAULT_PRIORITY - 1 // 999
                 ],
                 [
-                    'name'      => 'string_to_upper',
+                    'name'      => 'StringToUpper',
                     'priority'  => Filter\FilterChain::DEFAULT_PRIORITY + 1 //1001
                 ],
                 [
-                    'name'      => 'string_to_lower', // default priority 1000
+                    'name'      => 'StringToLower' // default priority 1000
                 ]
             ]
         ]);
@@ -767,13 +789,11 @@ class FactoryTest extends TestCase
 
     public function testSetInputFilterManagerWithServiceManager()
     {
-        $inputFilterManager = new InputFilterPluginManager;
         $serviceManager = new ServiceManager\ServiceManager;
-        $serviceManager->setService('ValidatorManager', new Validator\ValidatorPluginManager);
-        $serviceManager->setService('FilterManager', new Filter\FilterPluginManager);
-        $inputFilterManager->setServiceLocator($serviceManager);
-        $factory = $this->createDefaultFactory();
-        $factory->setInputFilterManager($inputFilterManager);
+        $inputFilterManager = new InputFilterPluginManager($serviceManager);
+        $serviceManager->setService('ValidatorManager', new Validator\ValidatorPluginManager($serviceManager));
+        $serviceManager->setService('FilterManager', new Filter\FilterPluginManager($serviceManager));
+        $factory = new Factory($inputFilterManager);
         $this->assertInstanceOf(
             Validator\ValidatorPluginManager::class,
             $factory->getDefaultValidatorChain()->getPluginManager()
@@ -786,15 +806,16 @@ class FactoryTest extends TestCase
 
     public function testSetInputFilterManagerWithoutServiceManager()
     {
-        $inputFilterManager = new InputFilterPluginManager();
-        $factory = $this->createDefaultFactory();
-        $factory->setInputFilterManager($inputFilterManager);
+        $smMock = $this->getMock(ContainerInterface::class);
+        $inputFilterManager = new InputFilterPluginManager($smMock);
+        $factory = new Factory($inputFilterManager);
         $this->assertSame($inputFilterManager, $factory->getInputFilterManager());
     }
 
     public function testSetInputFilterManagerOnConstruct()
     {
-        $inputFilterManager = new InputFilterPluginManager();
+        $smMock = $this->getMock(ContainerInterface::class);
+        $inputFilterManager = new InputFilterPluginManager($smMock);
         $factory = new Factory($inputFilterManager);
         $this->assertSame($inputFilterManager, $factory->getInputFilterManager());
     }
@@ -885,10 +906,10 @@ class FactoryTest extends TestCase
 
     public function testSuggestedTypeMayBePluginNameInInputFilterPluginManager()
     {
-        $factory = $this->createDefaultFactory();
-        $pluginManager = new InputFilterPluginManager();
+        $serviceManager = new ServiceManager\ServiceManager();
+        $pluginManager = new InputFilterPluginManager($serviceManager);
         $pluginManager->setService('bar', new Input('bar'));
-        $factory->setInputFilterManager($pluginManager);
+        $factory = new Factory($pluginManager);
 
         $input = $factory->createInput([
             'type' => 'bar'
@@ -898,9 +919,9 @@ class FactoryTest extends TestCase
 
     public function testInputFromPluginManagerMayBeFurtherConfiguredWithSpec()
     {
-        $factory = $this->createDefaultFactory();
-        $pluginManager = new InputFilterPluginManager();
+        $pluginManager = new InputFilterPluginManager(new ServiceManager\ServiceManager());
         $pluginManager->setService('bar', $barInput = new Input('bar'));
+        $factory = new Factory($pluginManager);
         $this->assertTrue($barInput->isRequired());
         $factory->setInputFilterManager($pluginManager);
 
@@ -932,7 +953,10 @@ class FactoryTest extends TestCase
     protected function createInputFilterPluginManagerMockForPlugin($pluginName, $pluginValue)
     {
         /** @var InputFilterPluginManager|MockObject $pluginManager */
-        $pluginManager = $this->getMock(InputFilterPluginManager::class);
+        $pluginManager = $this->getMockBuilder(InputFilterPluginManager::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $pluginManager->expects($this->atLeastOnce())
             ->method('has')
             ->with($pluginName)

--- a/test/InputFilterAbstractServiceFactoryTest.php
+++ b/test/InputFilterAbstractServiceFactoryTest.php
@@ -24,13 +24,19 @@ use Zend\Validator\ValidatorPluginManager;
  */
 class InputFilterAbstractServiceFactoryTest extends TestCase
 {
-    /** @var ServiceManager */
+    /**
+     * @var ServiceManager
+    */
     protected $services;
 
-    /** @var InputFilterPluginManager */
+    /**
+     * @var InputFilterPluginManager
+    */
     protected $filters;
 
-    /** @var InputFilterAbstractServiceFactory */
+    /**
+     * @var InputFilterAbstractServiceFactory
+     */
     protected $factory;
 
     public function setUp()
@@ -44,17 +50,31 @@ class InputFilterAbstractServiceFactoryTest extends TestCase
 
     public function testCannotCreateServiceIfNoConfigServicePresent()
     {
-        $this->assertFalse($this->factory->canCreate($this->getCompatContainer(), 'filter'));
-        // v2
-        $this->assertFalse($this->factory->canCreateServiceWithName($this->getCompatContainer(), 'filter', 'filter'));
+        if (method_exists($this->services, 'configure')) {
+            // v3
+            $method = 'canCreate';
+            $args = [$this->getCompatContainer(), 'filter'];
+        } else {
+            // v2
+            $method = 'canCreateServiceWithName';
+            $args = [$this->getCompatContainer(), 'filter', 'filter'];
+        }
+        $this->assertFalse(call_user_func_array([$this->factory, $method], $args));
     }
 
     public function testCannotCreateServiceIfConfigServiceDoesNotHaveInputFiltersConfiguration()
     {
         $this->services->setService('config', []);
-        $this->assertFalse($this->factory->canCreate($this->getCompatContainer(), 'filter'));
-        // v2
-        $this->assertFalse($this->factory->canCreateServiceWithName($this->getCompatContainer(), 'filter', 'filter'));
+        if (method_exists($this->services, 'configure')) {
+            // v3
+            $method = 'canCreate';
+            $args = [$this->getCompatContainer(), 'filter'];
+        } else {
+            // v2
+            $method = 'canCreateServiceWithName';
+            $args = [$this->getCompatContainer(), 'filter', 'filter'];
+        }
+        $this->assertFalse(call_user_func_array([$this->factory, $method], $args));
     }
 
     public function testCannotCreateServiceIfConfigInputFiltersDoesNotContainMatchingServiceName()
@@ -62,9 +82,16 @@ class InputFilterAbstractServiceFactoryTest extends TestCase
         $this->services->setService('config', [
             'input_filter_specs' => [],
         ]);
-        $this->assertFalse($this->factory->canCreate($this->getCompatContainer(), 'filter'));
-        // v2
-        $this->assertFalse($this->factory->canCreateServiceWithName($this->getCompatContainer(), 'filter', 'filter'));
+        if (method_exists($this->services, 'configure')) {
+            // v3
+            $method = 'canCreate';
+            $args = [$this->getCompatContainer(), 'filter'];
+        } else {
+            // v2
+            $method = 'canCreateServiceWithName';
+            $args = [$this->getCompatContainer(), 'filter', 'filter'];
+        }
+        $this->assertFalse(call_user_func_array([$this->factory, $method], $args));
     }
 
     public function testCanCreateServiceIfConfigInputFiltersContainsMatchingServiceName()
@@ -74,9 +101,16 @@ class InputFilterAbstractServiceFactoryTest extends TestCase
                 'filter' => [],
             ],
         ]);
-        $this->assertTrue($this->factory->canCreate($this->getCompatContainer(), 'filter'));
-        // v2
-        $this->assertTrue($this->factory->canCreateServiceWithName($this->getCompatContainer(), 'filter', 'filter'));
+        if (method_exists($this->services, 'configure')) {
+            // v3
+            $method = 'canCreate';
+            $args = [$this->getCompatContainer(), 'filter'];
+        } else {
+            // v2
+            $method = 'canCreateServiceWithName';
+            $args = [$this->getCompatContainer(), 'filter', 'filter'];
+        }
+        $this->assertTrue(call_user_func_array([$this->factory, $method], $args));
     }
 
     public function testCreatesInputFilterInstance()
@@ -86,11 +120,17 @@ class InputFilterAbstractServiceFactoryTest extends TestCase
                 'filter' => [],
             ],
         ]);
-        $filter = $this->factory->__invoke($this->getCompatContainer(), 'filter');
+        if (method_exists($this->services, 'configure')) {
+            // v3
+            $method = '__invoke';
+            $args = [$this->getCompatContainer(), 'filter'];
+        } else {
+            // v2
+            $method = 'createServiceWithName';
+            $args = [$this->getCompatContainer(), 'filter', 'filter'];
+        }
+        $filter = call_user_func_array([$this->factory, $method], $args);
         $this->assertInstanceOf(InputFilterInterface::class, $filter);
-        // v2
-        $v2filter = $this->factory->createServiceWithName($this->getCompatContainer(), 'filter', 'filter');
-        $this->assertEquals($filter, $v2filter);
     }
 
     /**
@@ -128,11 +168,17 @@ class InputFilterAbstractServiceFactoryTest extends TestCase
         ]);
 
 
-        $inputFilter = $this->factory->__invoke($this->getCompatContainer(), 'filter');
+        if (method_exists($this->services, 'configure')) {
+            // v3
+            $method = '__invoke';
+            $args = [$this->getCompatContainer(), 'filter'];
+        } else {
+            // v2
+            $method = 'createServiceWithName';
+            $args = [$this->getCompatContainer(), 'filter', 'filter'];
+        }
+        $inputFilter = call_user_func_array([$this->factory, $method], $args);
         $this->assertTrue($inputFilter->has('input'));
-        // v2
-        $v2InputFilter = $this->factory->createServiceWithName($this->getCompatContainer(), 'filter', 'filter');
-        $this->assertEquals($inputFilter, $v2InputFilter);
 
         $input = $inputFilter->get('input');
 

--- a/test/InputFilterPluginManagerCompatibilityTest.php
+++ b/test/InputFilterPluginManagerCompatibilityTest.php
@@ -12,10 +12,11 @@ namespace ZendTest\InputFilter;
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\InputFilter\Exception\RuntimeException;
 use Zend\InputFilter\InputFilterPluginManager;
+use Zend\ServiceManager\Config;
 use Zend\ServiceManager\ServiceManager;
 use Zend\ServiceManager\Test\CommonPluginManagerTrait;
 
-class MigrationTest extends TestCase
+class InputFilterPluginManagerCompatibilityTest extends TestCase
 {
     use CommonPluginManagerTrait;
 
@@ -38,5 +39,27 @@ class MigrationTest extends TestCase
     {
         // InputFilterManager accepts multiple instance types
         return;
+    }
+
+    public function testConstructorArgumentsAreOptionalUnderV2()
+    {
+        $plugins = $this->getPluginManager();
+        if (method_exists($plugins, 'configure')) {
+            $this->markTestSkipped('zend-servicemanager v3 plugin managers require a container argument');
+        }
+
+        $plugins = new InputFilterPluginManager();
+        $this->assertInstanceOf(InputFilterPluginManager::class, $plugins);
+    }
+
+    public function testConstructorAllowsConfigInstanceAsFirstArgumentUnderV2()
+    {
+        $plugins = $this->getPluginManager();
+        if (method_exists($plugins, 'configure')) {
+            $this->markTestSkipped('zend-servicemanager v3 plugin managers require a container argument');
+        }
+
+        $plugins = new InputFilterPluginManager(new Config([]));
+        $this->assertInstanceOf(InputFilterPluginManager::class, $plugins);
     }
 }

--- a/test/InputFilterPluginManagerTest.php
+++ b/test/InputFilterPluginManagerTest.php
@@ -52,7 +52,11 @@ class InputFilterPluginManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testIsNotSharedByDefault()
     {
-        $this->assertFalse($this->manager->shareByDefault());
+        $property = method_exists($this->manager, 'configure')
+            ? 'sharedByDefault' // v3
+            : 'shareByDefault'; // v2
+
+        $this->assertAttributeSame(false, $property, $this->manager);
     }
 
     public function testRegisteringInvalidElementRaisesException()

--- a/test/InputFilterPluginManagerTest.php
+++ b/test/InputFilterPluginManagerTest.php
@@ -18,7 +18,9 @@ use Zend\InputFilter\InputFilterInterface;
 use Zend\InputFilter\InputFilterPluginManager;
 use Zend\InputFilter\InputInterface;
 use Zend\ServiceManager\AbstractPluginManager;
+use Zend\ServiceManager\Exception\InvalidServiceException;
 use Zend\ServiceManager\ServiceLocatorInterface;
+use Zend\ServiceManager\ServiceManager;
 use Zend\Stdlib\InitializableInterface;
 use Zend\Validator\ValidatorPluginManager;
 
@@ -32,9 +34,15 @@ class InputFilterPluginManagerTest extends \PHPUnit_Framework_TestCase
      */
     protected $manager;
 
+    /**
+     * @var ServiceManager
+     */
+    protected $services;
+
     public function setUp()
     {
-        $this->manager = new InputFilterPluginManager();
+        $this->services = new ServiceManager();
+        $this->manager = new InputFilterPluginManager($this->services);
     }
 
     public function testIsASubclassOfAbstractPluginManager()
@@ -50,7 +58,7 @@ class InputFilterPluginManagerTest extends \PHPUnit_Framework_TestCase
     public function testRegisteringInvalidElementRaisesException()
     {
         $this->setExpectedException(
-            RuntimeException::class,
+            $this->getServiceNotFoundException(),
             'must implement Zend\InputFilter\InputFilterInterface or Zend\InputFilter\InputInterface'
         );
         $this->manager->setService('test', $this);
@@ -59,7 +67,7 @@ class InputFilterPluginManagerTest extends \PHPUnit_Framework_TestCase
     public function testLoadingInvalidElementRaisesException()
     {
         $this->manager->setInvokableClass('test', get_class($this));
-        $this->setExpectedException(RuntimeException::class);
+        $this->setExpectedException($this->getServiceNotFoundException());
         $this->manager->get('test');
     }
 
@@ -84,8 +92,6 @@ class InputFilterPluginManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testInputFilterInvokableClassSMDependenciesArePopulatedWithoutServiceLocator()
     {
-        $this->assertNull($this->manager->getServiceLocator(), 'Plugin manager is expected to no have a service locator');
-
         /** @var InputFilter $service */
         $service = $this->manager->get('inputfilter');
 
@@ -99,21 +105,15 @@ class InputFilterPluginManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testInputFilterInvokableClassSMDependenciesArePopulatedWithServiceLocator()
     {
-        $filterManager = $this->getMock(FilterPluginManager::class);
-        $validatorManager = $this->getMock(ValidatorPluginManager::class);
+        $filterManager = $this->getMockBuilder(FilterPluginManager::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $validatorManager = $this->getMockBuilder(ValidatorPluginManager::class)
+            ->disableOriginalConstructor()
+            ->getMock();
 
-        $serviceLocator = $this->createServiceLocatorInterfaceMock();
-        $serviceLocator->method('get')
-            ->willReturnMap(
-                [
-                    ['FilterManager', $filterManager],
-                    ['ValidatorManager', $validatorManager],
-                ]
-            )
-        ;
-
-        $this->manager->setServiceLocator($serviceLocator);
-        $this->assertSame($serviceLocator, $this->manager->getServiceLocator(), 'getServiceLocator() value not match');
+        $this->services->setService('FilterManager', $filterManager);
+        $this->services->setService('ValidatorManager', $validatorManager);
 
         /** @var InputFilter $service */
         $service = $this->manager->get('inputfilter');
@@ -210,5 +210,13 @@ class InputFilterPluginManagerTest extends \PHPUnit_Framework_TestCase
         $serviceLocator = $this->getMock(ServiceLocatorInterface::class);
 
         return $serviceLocator;
+    }
+
+    protected function getServiceNotFoundException()
+    {
+        if (method_exists($this->manager, 'configure')) {
+            return InvalidServiceException::class;
+        }
+        return RuntimeException::class;
     }
 }

--- a/test/MigrationTest.php
+++ b/test/MigrationTest.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\InputFilter;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\InputFilter\Exception\RuntimeException;
+use Zend\InputFilter\InputFilterPluginManager;
+use Zend\ServiceManager\ServiceManager;
+use Zend\ServiceManager\Test\CommonPluginManagerTrait;
+
+class MigrationTest extends TestCase
+{
+    use CommonPluginManagerTrait;
+
+    public function testInstanceOfMatches()
+    {
+        $this->markTestSkipped("InputFilterPluginManager accepts multiple instances");
+    }
+
+    protected function getPluginManager()
+    {
+        return new InputFilterPluginManager(new ServiceManager());
+    }
+
+    protected function getV2InvalidPluginException()
+    {
+        return RuntimeException::class;
+    }
+
+    protected function getInstanceOf()
+    {
+        // InputFilterManager accepts multiple instance types
+        return;
+    }
+}


### PR DESCRIPTION
This builds off of #86 and #95, with the following changes:

- dependency changes:
  - allow PHP 5.5+ **OR** PHP 7.0+
  - Use `^2.6` versions of zend-filter, zend-validator (no need to be more specific)
- build changes:
  - run a job per servicemanager version, per PHP version (prevent regressions specific to PHP version + SM version differences)
- incorporates feedback made during review of #95
- ensures the `InputFilterPluginManager` constructor is backwards compatible with zend-servicemanager v2.

A few other minor refactors were made for consistency with other components and/or to clarify context.