### PR TITLE
Expose zend-inputfilter as a config-provider / component

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ matrix:
       env:
         - SERVICE_MANAGER_VERSION="^2.7.5"
   allow_failures:
-    - php: 7
+    - php: hhvm
 
 notifications:
   irc: "irc.freenode.org#zftalk.dev"

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,10 @@
         "branch-alias": {
             "dev-master": "2.6-dev",
             "dev-develop": "2.7-dev"
+        },
+        "zf": {
+            "component": "Zend\\InputFilter",
+            "config-provider": "Zend\\InputFilter\\ConfigProvider"
         }
     },
     "autoload-dev": {

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-inputfilter for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\InputFilter;
+
+class ConfigProvider
+{
+    /**
+     * Return configuration for this component.
+     *
+     * @return array
+     */
+    public function __invoke()
+    {
+        return [
+            'dependencies' => $this->getDependencyConfig(),
+        ];
+    }
+
+    /**
+     * Return dependency mappings for this component.
+     *
+     * @return array
+     */
+    public function getDependencyConfig()
+    {
+        return [
+            'abstract_factories' => [
+                InputFilterAbstractServiceFactory::class,
+            ],
+            'factories' => [
+                'InputFilterManager' => InputFilterPluginManagerFactory::class,
+            ],
+        ];
+    }
+}

--- a/src/InputFilterPluginManagerFactory.php
+++ b/src/InputFilterPluginManagerFactory.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-inputfilter for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\InputFilter;
+
+use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class InputFilterPluginManagerFactory implements FactoryInterface
+{
+    /**
+     * zend-servicemanager v2 support for invocation options.
+     *
+     * @param array
+     */
+    protected $creationOptions;
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return InputFilterPluginManager
+     */
+    public function __invoke(ContainerInterface $container, $name, array $options = null)
+    {
+        return new InputFilterPluginManager($container, $options ?: []);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return InputFilterPluginManager
+     */
+    public function createService(ServiceLocatorInterface $container, $name = null, $requestedName = null)
+    {
+        return $this($container, $requestedName ?: InputFilterPluginManager::class, $this->creationOptions);
+    }
+
+    /**
+     * zend-servicemanager v2 support for invocation options.
+     *
+     * @param array $options
+     * @return void
+     */
+    public function setCreationOptions(array $options)
+    {
+        $this->creationOptions = $options;
+    }
+}

--- a/src/Module.php
+++ b/src/Module.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-inputfilter for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\InputFilter;
+
+class Module
+{
+    /**
+     * Return default zend-inputfilter configuration for zend-mvc applications.
+     */
+    public function getConfig()
+    {
+        $provider = new ConfigProvider();
+
+        return [
+            'service_manager' => $provider->getDependencyConfig(),
+        ];
+    }
+
+    /**
+     * Register a specification for the InputFilterManager with the ServiceListener.
+     *
+     * @param \Zend\ModuleManager\ModuleEvent
+     * @return void
+     */
+    public function init($event)
+    {
+        $container = $event->getParam('ServiceManager');
+        $serviceListener = $container->get('ServiceListener');
+
+        $serviceListener->addServiceManager(
+            'InputFilterManager',
+            'input_filters',
+            'Zend\ModuleManager\Feature\InputFilterProviderInterface',
+            'getInputFilterConfig'
+        );
+    }
+}

--- a/test/InputFilterPluginManagerFactoryTest.php
+++ b/test/InputFilterPluginManagerFactoryTest.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-inputfilter for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\InputFilter;
+
+use Interop\Container\ContainerInterface;
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\InputFilter\InputInterface;
+use Zend\InputFilter\InputFilterInterface;
+use Zend\InputFilter\InputFilterPluginManager;
+use Zend\InputFilter\InputFilterPluginManagerFactory;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class InputFilterPluginManagerFactoryTest extends TestCase
+{
+    public function testFactoryReturnsPluginManager()
+    {
+        $container = $this->prophesize(ContainerInterface::class)->reveal();
+        $factory = new InputFilterPluginManagerFactory();
+
+        $filters = $factory($container, InputFilterPluginManagerFactory::class);
+        $this->assertInstanceOf(InputFilterPluginManager::class, $filters);
+
+        if (method_exists($filters, 'configure')) {
+            // zend-servicemanager v3
+            $this->assertAttributeSame($container, 'creationContext', $filters);
+        } else {
+            // zend-servicemanager v2
+            $this->assertSame($container, $filters->getServiceLocator());
+        }
+    }
+
+    public function pluginProvider()
+    {
+        return [
+            'input' => [InputInterface::class],
+            'input-filter' => [InputFilterInterface::class],
+        ];
+    }
+
+    /**
+     * @depends testFactoryReturnsPluginManager
+     * @dataProvider pluginProvider
+     */
+    public function testFactoryConfiguresPluginManagerUnderContainerInterop($pluginType)
+    {
+        $container = $this->prophesize(ContainerInterface::class)->reveal();
+        $plugin = $this->prophesize($pluginType)->reveal();
+
+        $factory = new InputFilterPluginManagerFactory();
+        $filters = $factory($container, InputFilterPluginManagerFactory::class, [
+            'services' => [
+                'test' => $plugin,
+            ],
+        ]);
+        $this->assertSame($plugin, $filters->get('test'));
+    }
+
+    /**
+     * @depends testFactoryReturnsPluginManager
+     * @dataProvider pluginProvider
+     */
+    public function testFactoryConfiguresPluginManagerUnderServiceManagerV2($pluginType)
+    {
+        $container = $this->prophesize(ServiceLocatorInterface::class);
+        $container->willImplement(ContainerInterface::class);
+
+        $plugin = $this->prophesize($pluginType)->reveal();
+
+        $factory = new InputFilterPluginManagerFactory();
+        $factory->setCreationOptions([
+            'services' => [
+                'test' => $plugin,
+            ],
+        ]);
+
+        $filters = $factory->createService($container->reveal());
+        $this->assertSame($plugin, $filters->get('test'));
+    }
+}

--- a/test/InputFilterPluginManagerFactoryTest.php
+++ b/test/InputFilterPluginManagerFactoryTest.php
@@ -9,10 +9,10 @@ namespace ZendTest\InputFilter;
 
 use Interop\Container\ContainerInterface;
 use PHPUnit_Framework_TestCase as TestCase;
-use Zend\InputFilter\InputInterface;
 use Zend\InputFilter\InputFilterInterface;
 use Zend\InputFilter\InputFilterPluginManager;
 use Zend\InputFilter\InputFilterPluginManagerFactory;
+use Zend\InputFilter\InputInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
 class InputFilterPluginManagerFactoryTest extends TestCase


### PR DESCRIPTION
Adds:

- `InputFilterPluginManagerFactory`, ported from zend-mvc, with new tests.
- `ConfigProvider`, which maps the `InputFilterPluginManager` to its factory, and enables the `InputFilterAbstractServiceFactory`.
- `Module`, which does the above, and also provides an `init()` method for
 notifying the zend-modulemanager `ServiceListener` of the `input_filters` specification for aggregating input filter configuration.