### PR TITLE
Fix the module initializer

### DIFF
--- a/src/Module.php
+++ b/src/Module.php
@@ -24,11 +24,12 @@ class Module
     /**
      * Register a specification for the InputFilterManager with the ServiceListener.
      *
-     * @param \Zend\ModuleManager\ModuleEvent
+     * @param \Zend\ModuleManager\ModuleManager $moduleManager
      * @return void
      */
-    public function init($event)
+    public function init($moduleManager)
     {
+        $event = $moduleManager->getEvent();
         $container = $event->getParam('ServiceManager');
         $serviceListener = $container->get('ServiceListener');
 


### PR DESCRIPTION
Initializers actually receive the module manager itself, not the module event. As such, we have to pull the event from the module manager instance.