### PR TITLE
fix bc break in InputFilterPluginManager::populateFactory

### DIFF
--- a/src/InputFilterPluginManager.php
+++ b/src/InputFilterPluginManager.php
@@ -77,23 +77,20 @@ class InputFilterPluginManager extends AbstractPluginManager
     /**
      * Inject this and populate the factory with filter chain and validator chain
      *
-     * @param mixed $first
-     * @param mixed $second
+     * @param ContainerInterface|InputFilter $containerOrInputFilter    When using ServiceManager v3
+     *                                                                  this will be the plugin manager instance
+     * @param InputFilter                    $inputFilter               This is only used with ServiceManager v3
      */
-    public function populateFactory($first, $second)
+    public function populateFactory($containerOrInputFilter, $inputFilter = null)
     {
-        if ($first instanceof ContainerInterface) {
-            $container = $first;
-            $inputFilter = $second;
-        } else {
-            $container = $second;
-            $inputFilter = $first;
-        }
-        if ($inputFilter instanceof InputFilter) {
-            $factory = $inputFilter->getFactory();
+        $inputFilter = $containerOrInputFilter instanceof ContainerInterface ? $inputFilter : $containerOrInputFilter;
 
-            $factory->setInputFilterManager($this);
+        if (! $inputFilter instanceof InputFilter) {
+            return;
         }
+
+        $factory = $inputFilter->getFactory();
+        $factory->setInputFilterManager($this);
     }
 
     /**

--- a/test/InputFilterPluginManagerTest.php
+++ b/test/InputFilterPluginManagerTest.php
@@ -183,6 +183,14 @@ class InputFilterPluginManagerTest extends \PHPUnit_Framework_TestCase
         $initializableProphecy->init()->shouldBeCalled();
     }
 
+    public function testPopulateFactories()
+    {
+        $inputFilter = new InputFilter();
+        $this->manager->populateFactory($inputFilter);
+
+        $this->assertSame($this->manager, $inputFilter->getFactory()->getInputFilterManager());
+    }
+
     /**
      * @return MockObject|InputFilterInterface
      */


### PR DESCRIPTION
this PR makes `InputFilterPluginManager::populateFactory` signature change
introduced by #96 backward compatible, while still ensuring service manager v3 compatibility.