### PR TITLE
Fixes issue with using InputFilterAbstractFactory with application services

### DIFF
--- a/test/InputFilterAbstractServiceFactoryTest.php
+++ b/test/InputFilterAbstractServiceFactoryTest.php
@@ -274,4 +274,31 @@ class InputFilterAbstractServiceFactoryTest extends TestCase
         $this->assertInstanceOf('Zend\InputFilter\InputFilterPluginManager', $inputFilterManager);
         $this->assertInstanceOf('ZendTest\InputFilter\TestAsset\Foo', $inputFilterManager->get('foo'));
     }
+
+    /**
+     * @group 123
+     */
+    public function testAllowsPassingNonPluginManagerContainerToFactoryWithServiceManagerV2()
+    {
+        $this->services->setService('config', [
+            'input_filter_specs' => [
+                'filter' => [],
+            ],
+        ]);
+        if (method_exists($this->services, 'configure')) {
+            // v3
+            $canCreate = 'canCreate';
+            $create = '__invoke';
+            $args = [$this->services, 'filter'];
+        } else {
+            // v2
+            $canCreate = 'canCreateServiceWithName';
+            $create = 'createServiceWithName';
+            $args = [$this->services, 'filter', 'filter'];
+        }
+
+        $this->assertTrue(call_user_func_array([$this->factory, $canCreate], $args));
+        $inputFilter = call_user_func_array([$this->factory, $create], $args);
+        $this->assertInstanceOf(InputFilterInterface::class, $inputFilter);
+    }
 }


### PR DESCRIPTION
As reported in #123, under zend-servicemanager v2, the `InputFilterAbstractFactory` raises a fatal error when calling `getServiceLocator()` if the container passed to the abstract factory is not a plugin manager, but instead the application-level service container.

This patch updates the implementation to add some detection to determine if the container is a plugin manager when used under v2, and, if so, only then attempt to pull the parent service container. Additionally, it will now use itself if no parent container is present (this will typically cause the `canCreate()` test to fail anyways).

All typehints on `ServiceLocatorInterface` were modified to `ContainerInterface` unless they were part of an existing interface definition, to ensure inner consistency, and forwards compatibility with v3.