### PR TITLE
`getUnknown` in CollectionInputFilter

### DIFF
--- a/src/BaseInputFilter.php
+++ b/src/BaseInputFilter.php
@@ -540,21 +540,7 @@ class BaseInputFilter implements
      */
     public function hasUnknown()
     {
-        if (null === $this->data) {
-            throw new Exception\RuntimeException(sprintf(
-                '%s: no data present!',
-                __METHOD__
-            ));
-        }
-
-        $data   = array_keys($this->data);
-        $inputs = array_keys($this->inputs);
-        $diff   = array_diff($data, $inputs);
-        if (!empty($diff)) {
-            return count(array_intersect($diff, $inputs)) == 0;
-        }
-
-        return false;
+        return count($this->getUnknown()) > 0;
     }
 
     /**

--- a/src/CollectionInputFilter.php
+++ b/src/CollectionInputFilter.php
@@ -252,4 +252,33 @@ class CollectionInputFilter extends InputFilter
     {
         return $this->collectionMessages;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getUnknown()
+    {
+        if (!is_array($this->data) || !$this->data) {
+            throw new Exception\RuntimeException(sprintf(
+                '%s: no data present!',
+                __METHOD__
+            ));
+        }
+
+        $inputFilter = $this->getInputFilter();
+
+        $unknownInputs = [];
+        foreach ($this->data as $key => $data) {
+            if (!is_array($data)) {
+                $data = [];
+            }
+            $inputFilter->setData($data);
+
+            if ($unknown = $inputFilter->getUnknown()) {
+                $unknownInputs[$key] = $unknown;
+            }
+        }
+
+        return $unknownInputs;
+    }
 }

--- a/test/CollectionInputFilterTest.php
+++ b/test/CollectionInputFilterTest.php
@@ -421,6 +421,7 @@ class CollectionInputFilterTest extends TestCase
 
         $unknown = $collectionInputFilter->getUnknown();
 
+        $this->assertFalse($collectionInputFilter->hasUnknown());
         $this->assertCount(0, $unknown);
     }
 
@@ -441,6 +442,7 @@ class CollectionInputFilterTest extends TestCase
 
         $unknown = $collectionInputFilter->getUnknown();
 
+        $this->assertTrue($collectionInputFilter->hasUnknown());
         $this->assertEquals([['baz' => 'hey'], ['tor' => 'ver']], $unknown);
     }
 }

--- a/test/CollectionInputFilterTest.php
+++ b/test/CollectionInputFilterTest.php
@@ -396,4 +396,51 @@ class CollectionInputFilterTest extends TestCase
 
         return $inputFilter;
     }
+
+    public function testGetUnknownWhenDataAreNotProvidedThrowsRuntimeException()
+    {
+        $this->setExpectedException(RuntimeException::class);
+
+        $this->inputFilter->getUnknown();
+    }
+
+    public function testGetUnknownWhenAllFieldsAreKnownReturnsAnEmptyArray()
+    {
+        $inputFilter = new InputFilter();
+        $inputFilter->add([
+            'name' => 'foo',
+        ]);
+
+        $collectionInputFilter = $this->inputFilter;
+        $collectionInputFilter->setInputFilter($inputFilter);
+
+        $collectionInputFilter->setData([
+            ['foo' => 'bar'],
+            ['foo' => 'baz'],
+        ]);
+
+        $unknown = $collectionInputFilter->getUnknown();
+
+        $this->assertCount(0, $unknown);
+    }
+
+    public function testGetUnknownFieldIsUnknown()
+    {
+        $inputFilter = new InputFilter();
+        $inputFilter->add([
+            'name' => 'foo',
+        ]);
+
+        $collectionInputFilter = new CollectionInputFilter();
+        $collectionInputFilter->setInputFilter($inputFilter);
+
+        $collectionInputFilter->setData([
+            ['foo' => 'bar', 'baz' => 'hey'],
+            ['foo' => 'car', 'tor' => 'ver']
+        ]);
+
+        $unknown = $collectionInputFilter->getUnknown();
+
+        $this->assertEquals([['baz' => 'hey'], ['tor' => 'ver']], $unknown);
+    }
 }

--- a/test/CollectionInputFilterTest.php
+++ b/test/CollectionInputFilterTest.php
@@ -432,7 +432,7 @@ class CollectionInputFilterTest extends TestCase
             'name' => 'foo',
         ]);
 
-        $collectionInputFilter = new CollectionInputFilter();
+        $collectionInputFilter = $this->inputFilter;
         $collectionInputFilter->setInputFilter($inputFilter);
 
         $collectionInputFilter->setData([

--- a/test/InputFilterTest.php
+++ b/test/InputFilterTest.php
@@ -11,11 +11,9 @@ namespace ZendTest\InputFilter;
 
 use ArrayIterator;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
-use Zend\InputFilter\Exception\RuntimeException;
 use Zend\InputFilter\Factory;
 use Zend\InputFilter\Input;
 use Zend\InputFilter\InputFilter;
-use Zend\Validator\StringLength;
 
 /**
  * @covers Zend\InputFilter\InputFilter
@@ -79,63 +77,5 @@ class InputFilterTest extends BaseInputFilterTest
         $factory = $this->getMock(Factory::class);
 
         return $factory;
-    }
-
-    public function testGetUnknownWhenDataAreNotProvidedThrowsRuntimeException()
-    {
-        $this->setExpectedException(RuntimeException::class);
-
-        $this->inputFilter->getUnknown();
-    }
-
-    public function testGetUnknownWhenAllFieldsAreKnownReturnsAnEmptyArray()
-    {
-        $this->inputFilter->add([
-            'name' => 'foo',
-        ]);
-
-        $this->inputFilter->setData(['foo' => 'bar']);
-
-        $unknown = $this->inputFilter->getUnknown();
-
-        $this->assertCount(0, $unknown);
-    }
-
-    public function testGetUnknownFieldIsUnknown()
-    {
-        $this->inputFilter->add([
-            'name' => 'foo',
-        ]);
-
-        $this->inputFilter->setData(['foo' => 'bar', 'baz' => 'hey']);
-
-        $unknown = $this->inputFilter->getUnknown();
-
-        $this->assertCount(1, $unknown);
-        $this->assertEquals(['baz' => 'hey'], $unknown);
-    }
-
-    public function testGetUnknownWhenDataAreNotValid()
-    {
-        $this->inputFilter->add([
-            'name' => 'foo',
-            'validators' => [
-                [
-                    'name' => StringLength::class,
-                    'options' => [
-                        'min' => 3,
-                    ],
-                ],
-            ],
-        ]);
-
-        $this->inputFilter->setData(['foo' => 'a', 'bar' => 'baz']);
-
-        $isValid = $this->inputFilter->isValid();
-        $unknown = $this->inputFilter->getUnknown();
-
-        $this->assertFalse($isValid);
-        $this->assertCount(1, $unknown);
-        $this->assertEquals(['bar' => 'baz'], $unknown);
     }
 }

--- a/test/InputFilterTest.php
+++ b/test/InputFilterTest.php
@@ -11,9 +11,11 @@ namespace ZendTest\InputFilter;
 
 use ArrayIterator;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use Zend\InputFilter\Exception\RuntimeException;
 use Zend\InputFilter\Factory;
 use Zend\InputFilter\Input;
 use Zend\InputFilter\InputFilter;
+use Zend\Validator\StringLength;
 
 /**
  * @covers Zend\InputFilter\InputFilter
@@ -77,5 +79,63 @@ class InputFilterTest extends BaseInputFilterTest
         $factory = $this->getMock(Factory::class);
 
         return $factory;
+    }
+
+    public function testGetUnknownWhenDataAreNotProvidedThrowsRuntimeException()
+    {
+        $this->setExpectedException(RuntimeException::class);
+
+        $this->inputFilter->getUnknown();
+    }
+
+    public function testGetUnknownWhenAllFieldsAreKnownReturnsAnEmptyArray()
+    {
+        $this->inputFilter->add([
+            'name' => 'foo',
+        ]);
+
+        $this->inputFilter->setData(['foo' => 'bar']);
+
+        $unknown = $this->inputFilter->getUnknown();
+
+        $this->assertCount(0, $unknown);
+    }
+
+    public function testGetUnknownFieldIsUnknown()
+    {
+        $this->inputFilter->add([
+            'name' => 'foo',
+        ]);
+
+        $this->inputFilter->setData(['foo' => 'bar', 'baz' => 'hey']);
+
+        $unknown = $this->inputFilter->getUnknown();
+
+        $this->assertCount(1, $unknown);
+        $this->assertEquals(['baz' => 'hey'], $unknown);
+    }
+
+    public function testGetUnknownWhenDataAreNotValid()
+    {
+        $this->inputFilter->add([
+            'name' => 'foo',
+            'validators' => [
+                [
+                    'name' => StringLength::class,
+                    'options' => [
+                        'min' => 3,
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->inputFilter->setData(['foo' => 'a', 'bar' => 'baz']);
+
+        $isValid = $this->inputFilter->isValid();
+        $unknown = $this->inputFilter->getUnknown();
+
+        $this->assertFalse($isValid);
+        $this->assertCount(1, $unknown);
+        $this->assertEquals(['bar' => 'baz'], $unknown);
     }
 }


### PR DESCRIPTION
Method `getUnknown` works wrong on `CollectionInputFilter`.
It was returning all fields, not only unknown.

It should work similar to `isValid` method - so unknown fields should be checked for each dataset and result should be collection of unknown fields (to be more specific pairs `field => value`).

So for example: we have input filter with field "foo" (and we are using this input filter in our CollectionInputFilter). The input data are:
```php
[
    ['foo' => 'bar'],
    ['baz' => 'bar'],
]
```

so the second dataset (index 1!) has unknown field `baz`.

The result of `getUnknown` method should be:
```php
[
    1 => ['baz' => 'bar'],
]
```

but currently is exactly the same as the input data.

In this PR fixed behavior of this method in `CollectionInputFilter` + tests.
Also updated method `hasUnknown` to reuse `getUnknown` results.