### PR TITLE
Do not allow setting invalid collections or collection items

### DIFF
--- a/src/CollectionInputFilter.php
+++ b/src/CollectionInputFilter.php
@@ -143,7 +143,7 @@ class CollectionInputFilter extends InputFilter
             throw new Exception\InvalidArgumentException(sprintf(
                 '%s expects an array or Traversable collection; invalid collection of type %s provided',
                 __METHOD__,
-                (is_object($data) ? get_class($data) : gettype($data))
+                is_object($data) ? get_class($data) : gettype($data)
             ));
         }
 
@@ -156,7 +156,7 @@ class CollectionInputFilter extends InputFilter
                 '%s expects each item in a collection to be an array or Traversable; '
                 . 'invalid item in collection of type %s detected',
                 __METHOD__,
-                (is_object($item) ? get_class($item) : gettype($item))
+                is_object($item) ? get_class($item) : gettype($item)
             ));
         }
 

--- a/src/CollectionInputFilter.php
+++ b/src/CollectionInputFilter.php
@@ -178,13 +178,11 @@ class CollectionInputFilter extends InputFilter
             }
         }
 
-        if (is_scalar($this->data)
-            || count($this->data) < $this->getCount()
-        ) {
+        if (count($this->data) < $this->getCount()) {
             $valid = false;
         }
 
-        if (empty($this->data) || is_scalar($this->data)) {
+        if (empty($this->data)) {
             $this->clearValues();
             $this->clearRawValues();
 

--- a/src/CollectionInputFilter.php
+++ b/src/CollectionInputFilter.php
@@ -139,8 +139,28 @@ class CollectionInputFilter extends InputFilter
      */
     public function setData($data)
     {
-        $this->data = $data;
+        if (! (is_array($data) || $data instanceof Traversable)) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                '%s expects an array or Traversable collection; invalid collection of type %s provided',
+                __METHOD__,
+                (is_object($data) ? get_class($data) : gettype($data))
+            ));
+        }
 
+        foreach ($data as $item) {
+            if (is_array($item) || $item instanceof Traversable) {
+                continue;
+            }
+
+            throw new Exception\InvalidArgumentException(sprintf(
+                '%s expects each item in a collection to be an array or Traversable; '
+                . 'invalid item in collection of type %s detected',
+                __METHOD__,
+                (is_object($item) ? get_class($item) : gettype($item))
+            ));
+        }
+
+        $this->data = $data;
         return $this;
     }
 
@@ -172,9 +192,6 @@ class CollectionInputFilter extends InputFilter
         }
 
         foreach ($this->data as $key => $data) {
-            if (!is_array($data)) {
-                $data = [];
-            }
             $inputFilter->setData($data);
 
             if (null !== $this->validationGroup) {
@@ -258,7 +275,7 @@ class CollectionInputFilter extends InputFilter
      */
     public function getUnknown()
     {
-        if (!is_array($this->data) || !$this->data) {
+        if (!$this->data) {
             throw new Exception\RuntimeException(sprintf(
                 '%s: no data present!',
                 __METHOD__
@@ -269,9 +286,6 @@ class CollectionInputFilter extends InputFilter
 
         $unknownInputs = [];
         foreach ($this->data as $key => $data) {
-            if (!is_array($data)) {
-                $data = [];
-            }
             $inputFilter->setData($data);
 
             if ($unknown = $inputFilter->getUnknown()) {

--- a/src/CollectionInputFilter.php
+++ b/src/CollectionInputFilter.php
@@ -182,7 +182,7 @@ class CollectionInputFilter extends InputFilter
             $valid = false;
         }
 
-        if (empty($this->data)) {
+        if (! $this->data) {
             $this->clearValues();
             $this->clearRawValues();
 

--- a/test/CollectionInputFilterTest.php
+++ b/test/CollectionInputFilterTest.php
@@ -320,8 +320,8 @@ class CollectionInputFilterTest extends TestCase
     public function countVsDataProvider()
     {
         $data0 = [];
-        $data1 = ['A' => 'a'];
-        $data2 = ['A' => 'a', 'B' => 'b'];
+        $data1 = [['A' => 'a']];
+        $data2 = [['A' => 'a'], ['B' => 'b']];
 
         // @codingStandardsIgnoreStart
         return [

--- a/test/CollectionInputFilterTest.php
+++ b/test/CollectionInputFilterTest.php
@@ -106,15 +106,6 @@ class CollectionInputFilterTest extends TestCase
         $this->assertEquals(1, $this->inputFilter->getCount());
     }
 
-    public function testInvalidCollectionIsNotValid()
-    {
-        $data = 1;
-
-        $this->inputFilter->setData($data);
-
-        $this->assertFalse($this->inputFilter->isValid());
-    }
-
     /**
      * @dataProvider dataVsValidProvider
      */

--- a/test/CollectionInputFilterTest.php
+++ b/test/CollectionInputFilterTest.php
@@ -15,6 +15,7 @@ use PHPUnit_Framework_TestCase as TestCase;
 use stdClass;
 use Zend\InputFilter\BaseInputFilter;
 use Zend\InputFilter\CollectionInputFilter;
+use Zend\InputFilter\Exception\InvalidArgumentException;
 use Zend\InputFilter\Exception\RuntimeException;
 use Zend\InputFilter\Input;
 use Zend\InputFilter\InputFilter;
@@ -444,5 +445,69 @@ class CollectionInputFilterTest extends TestCase
 
         $this->assertTrue($collectionInputFilter->hasUnknown());
         $this->assertEquals([['baz' => 'hey'], ['tor' => 'ver']], $unknown);
+    }
+
+    public function invalidCollections()
+    {
+        return [
+            'null'       => [[['this' => 'is valid'], null]],
+            'false'      => [[['this' => 'is valid'], false]],
+            'true'       => [[['this' => 'is valid'], true]],
+            'zero'       => [[['this' => 'is valid'], 0]],
+            'int'        => [[['this' => 'is valid'], 1]],
+            'zero-float' => [[['this' => 'is valid'], 0.0]],
+            'float'      => [[['this' => 'is valid'], 1.1]],
+            'string'     => [[['this' => 'is valid'], 'this is not']],
+            'object'     => [[['this' => 'is valid'], (object) ['this' => 'is invalid']]],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidCollections
+     */
+    public function testSettingDataAsArrayWithInvalidCollectionsRaisesException($data)
+    {
+        $collectionInputFilter = $this->inputFilter;
+
+        $this->setExpectedException(InvalidArgumentException::class, 'invalid item in collection');
+        $collectionInputFilter->setData($data);
+    }
+
+    /**
+     * @dataProvider invalidCollections
+     */
+    public function testSettingDataAsTraversableWithInvalidCollectionsRaisesException($data)
+    {
+        $collectionInputFilter = $this->inputFilter;
+        $data = new ArrayIterator($data);
+
+        $this->setExpectedException(InvalidArgumentException::class, 'invalid item in collection');
+        $collectionInputFilter->setData($data);
+    }
+
+    public function invalidDataType()
+    {
+        return [
+            'null'       => [null],
+            'false'      => [false],
+            'true'       => [true],
+            'zero'       => [0],
+            'int'        => [1],
+            'zero-float' => [0.0],
+            'float'      => [1.1],
+            'string'     => ['this is not'],
+            'object'     => [(object) ['this' => 'is invalid']],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidDataType
+     */
+    public function testSettingDataWithNonArrayNonTraversableRaisesException($data)
+    {
+        $collectionInputFilter = $this->inputFilter;
+
+        $this->setExpectedException(InvalidArgumentException::class, 'invalid collection');
+        $collectionInputFilter->setData($data);
     }
 }


### PR DESCRIPTION
Unlike the base input filter, `CollectionInputFilter::setData()` has always allowed *any* data in. It only raises error conditions in one situation: when validating, if the data is not an array or traversable.

Otherwise, as it iterates through the data, if any item is not an array, it casts it to... an empty array.

This patch updates the behavior of `setData()` to do the following:

- If the `$data` argument is not an array or `Traversable`, it raises an `InvalidArgumentException`.
- If any item in `$data` is not an array or `Traversable`, it raises an `InvalidArgumentException`.

~~Unfortunately, this change now introduces six errors in the test suite.  From my cursory inspection, each of these are malformed tests, in my opinion, as they represent invalid data in the first place.

A later commit will take care of those issues.~~

This change presents a slight behavioral break with previous versions. However, it corrects the previous behavior, as invalid collections and/or invalid items in collections previously would have led to inconsistent state internally (both during validation and when retrieving unknown values), and potentially false positive validation (particularly if any given item was not an array/Traversable, and the collection input filter had no required values).