### PR TITLE
Fix #114 - validate collection

### DIFF
--- a/src/Input.php
+++ b/src/Input.php
@@ -387,6 +387,10 @@ class Input implements
      */
     public function isValid($context = null)
     {
+        if (is_array($this->errorMessage)) {
+            $this->errorMessage = null;
+        }
+
         $value           = $this->getValue();
         $hasValue        = $this->hasValue();
         $empty           = ($value === null || $value === '' || $value === []);

--- a/test/CollectionInputFilterTest.php
+++ b/test/CollectionInputFilterTest.php
@@ -542,11 +542,14 @@ class CollectionInputFilterTest extends TestCase
         // @codingStandardsIgnoreStart
         $this->assertFalse($isValid);
         $this->assertCount(2, $messages);
+
         $this->assertArrayHasKey('email', $messages[0]);
+        $this->assertCount(1, $messages[0]['email']);
         $this->assertContains('Value is required and can\'t be empty', $messages[0]['email']);
+
         $this->assertArrayHasKey('email', $messages[1]);
-        $this->assertNotContains('Value is required and can\'t be empty', $messages[1]['email']);
         $this->assertCount(3, $messages[1]['email']);
+        $this->assertNotContains('Value is required and can\'t be empty', $messages[1]['email']);
         $this->assertContains('\'tom\' is not a valid hostname for the email address', $messages[1]['email']);
         $this->assertContains('The input does not match the expected structure for a DNS hostname', $messages[1]['email']);
         $this->assertContains('The input appears to be a local network name but local network names are not allowed', $messages[1]['email']);

--- a/test/CollectionInputFilterTest.php
+++ b/test/CollectionInputFilterTest.php
@@ -552,4 +552,54 @@ class CollectionInputFilterTest extends TestCase
         $this->assertContains('The input appears to be a local network name but local network names are not allowed', $messages[1]['email']);
         // @codingStandardsIgnoreEnd
     }
+
+    public function testValidateCollectionWithCustomErrorMessage()
+    {
+        $inputFilter = new InputFilter();
+        $inputFilter->add([
+            'name' => 'email',
+            'required' => true,
+            'validators' => [
+                ['name' => EmailAddress::class],
+                ['name' => NotEmpty::class],
+            ],
+            'error_message' => 'CUSTOM ERROR MESSAGE',
+        ]);
+        $inputFilter->add([
+            'name' => 'name',
+            'required' => true,
+            'validators' => [
+                ['name' => NotEmpty::class],
+            ],
+        ]);
+
+        $collectionInputFilter = $this->inputFilter;
+        $collectionInputFilter->setInputFilter($inputFilter);
+
+        $collectionInputFilter->setData([
+            [
+                'name' => 'Tom',
+            ],
+            [
+                'email' => 'tom@tom',
+                'name' => 'Tom',
+            ],
+        ]);
+
+        $isValid = $collectionInputFilter->isValid();
+        $messages = $collectionInputFilter->getMessages();
+
+
+        $this->assertFalse($isValid);
+        $this->assertCount(2, $messages);
+
+        $this->assertArrayHasKey('email', $messages[0]);
+        $this->assertCount(1, $messages[0]['email']);
+        $this->assertContains('CUSTOM ERROR MESSAGE', $messages[0]['email']);
+        $this->assertNotContains('Value is required and can\'t be empty', $messages[0]['email']);
+
+        $this->assertArrayHasKey('email', $messages[1]);
+        $this->assertCount(1, $messages[1]['email']);
+        $this->assertContains('CUSTOM ERROR MESSAGE', $messages[1]['email']);
+    }
 }

--- a/test/CollectionInputFilterTest.php
+++ b/test/CollectionInputFilterTest.php
@@ -542,6 +542,8 @@ class CollectionInputFilterTest extends TestCase
         // @codingStandardsIgnoreStart
         $this->assertFalse($isValid);
         $this->assertCount(2, $messages);
+        $this->assertArrayHasKey('email', $messages[0]);
+        $this->assertContains('Value is required and can\'t be empty', $messages[0]['email']);
         $this->assertArrayHasKey('email', $messages[1]);
         $this->assertNotContains('Value is required and can\'t be empty', $messages[1]['email']);
         $this->assertCount(3, $messages[1]['email']);


### PR DESCRIPTION
So far only test implemented as reported in #114.
I had a look on it and it seems to be a quite complex...

**Edited:** 
`errorMessage` is now cleared (to `null`) before validation the Input only when it is an `array`.
Why? The setter method `setErrorMessage` accept any type, but there is casting to `(string)`.
Method `prepareRequiredValidationFailureMessage` called in `isValid` sets errorMessage to an array, and in this case we have to clear it before each validation.

Probably it needs more refactor in future. Because current complexity of these validation there is terrible!