### PR TITLE
zend-servicemanager is not a dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,14 +14,15 @@
     },
     "require": {
         "php": "^5.5 || ^7.0",
+        "container-interop/container-interop": "^1.0",
         "zendframework/zend-filter": "^2.6",
         "zendframework/zend-validator": "^2.6",
+        "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
         "zendframework/zend-stdlib": "^2.7 || ^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8",
-        "squizlabs/php_codesniffer": "^2.6.2",
-        "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3"
+        "squizlabs/php_codesniffer": "^2.6.2"
     },
     "suggest": {
         "zendframework/zend-servicemanager": "To support plugin manager support"


### PR DESCRIPTION
zendframework/zend-servicemanager and container-interop/container-interop are explicitly referenced by several classes in this package, so they should always be required.

i included zendframework/zend-inputfilter in a package without requiring zend-servicemanager and the input filter factory crashed due to the unsatisfied dependency.