### PR TITLE
Add PHP 7.2 support, drop HHVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,17 +58,17 @@ matrix:
     - php: 7.1
       env:
         - DEPS=latest
-    - php: nightly
+    - php: 7.2
       env:
         - DEPS=lowest
-    - php: nightly
+    - php: 7.2
       env:
         - DEPS=locked
-    - php: nightly
+    - php: 7.2
       env:
         - DEPS=latest
   allow_failures:
-    - php: nightly
+    - php: 7.2
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,17 +58,17 @@ matrix:
     - php: 7.1
       env:
         - DEPS=latest
-    - php: hhvm
+    - php: nightly
       env:
         - DEPS=lowest
-    - php: hhvm
+    - php: nightly
       env:
         - DEPS=locked
-    - php: hhvm
+    - php: nightly
       env:
         - DEPS=latest
   allow_failures:
-    - php: hhvm
+    - php: nightly
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,12 @@ language: php
 
 branches:
   except:
-    - /^release-\d+\.\d+\.\d+.*$/
+    - /^release-.*$/
     - /^ghgfk-.*$/
 
 cache:
   directories:
-    - $HOME/.composer/cache
-    - vendor
+    - $HOME/.composer/
     - $HOME/.local
     - zf-mkdoc-theme
 
@@ -79,14 +78,13 @@ install:
   - travis_retry composer install $COMPOSER_ARGS --ignore-platform-reqs
   - if [[ $TRAVIS_PHP_VERSION =~ ^5.6 ]]; then travis_retry composer update $COMPOSER_ARGS --with-dependencies $LEGACY_DEPS ; fi
   - if [[ $DEPS == 'latest' ]]; then travis_retry composer update $COMPOSER_ARGS ; fi
-  - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update --prefer-lowest --prefer-stable $COMPOSER_ARGS ; fi
+  - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update $COMPOSER_ARGS --prefer-lowest --prefer-stable ; fi
   - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry composer require --dev $COMPOSER_ARGS $COVERAGE_DEPS ; fi
   - stty cols 120
   - COLUMNS=120 composer show
 
 script:
-  - if [[ $TEST_COVERAGE == 'true' ]]; then composer test-coverage ; fi
-  - if [[ $TEST_COVERAGE != 'true' ]]; then composer test ; fi
+  - if [[ $TEST_COVERAGE == 'true' ]]; then composer test-coverage ; else composer test ; fi
   - if [[ $CS_CHECK == 'true' ]]; then composer cs-check ; fi
   - if [[ $DEPLOY_DOCS == "true" && "$TRAVIS_TEST_RESULT" == "0" ]]; then wget -O theme-installer.sh "https://raw.githubusercontent.com/zendframework/zf-mkdoc-theme/master/theme-installer.sh" ; chmod 755 theme-installer.sh ; ./theme-installer.sh ; fi
 

--- a/src/CollectionInputFilter.php
+++ b/src/CollectionInputFilter.php
@@ -167,7 +167,7 @@ class CollectionInputFilter extends InputFilter
     /**
      * {@inheritdoc}
      */
-    public function isValid()
+    public function isValid($context = null)
     {
         $inputFilter = $this->getInputFilter();
         $valid = true;

--- a/test/ConfigProviderTest.php
+++ b/test/ConfigProviderTest.php
@@ -7,12 +7,13 @@
 
 namespace ZendTest\InputFilter;
 
+use PHPUnit\Framework\TestCase;
 use Zend\InputFilter\ConfigProvider;
 use Zend\InputFilter\InputFilterAbstractServiceFactory;
 use Zend\InputFilter\InputFilterPluginManager;
 use Zend\InputFilter\InputFilterPluginManagerFactory;
 
-final class ConfigProviderTest extends \PHPUnit_Framework_TestCase
+final class ConfigProviderTest extends TestCase
 {
     public function testProvidesExpectedConfiguration()
     {


### PR DESCRIPTION
- [x] Cherry-pick https://github.com/zendframework/zend-inputfilter/pull/141
- [x] Adopt recent `.travis.yml` ZF standards ([zend-session/.travis.yml](https://github.com/zendframework/zend-session/blob/develop/.travis.yml) picked)
- [x] Drop HVVM
- [x] Test PHP 7.2
- [x] Add partial PHP 7.2 support
    1. `Fatal error: Declaration of Zend\InputFilter\CollectionInputFilter::isValid() must be compatible with Zend\InputFilter\BaseInputFilter::isValid($context = NULL) in /tmp/zend-inputfilter/src/CollectionInputFilter.php`