### PR TITLE
fix proto for PHP 7.2

### DIFF
--- a/src/CollectionInputFilter.php
+++ b/src/CollectionInputFilter.php
@@ -167,7 +167,7 @@ class CollectionInputFilter extends InputFilter
     /**
      * {@inheritdoc}
      */
-    public function isValid()
+    public function isValid($context = null)
     {
         $inputFilter = $this->getInputFilter();
         $valid = true;


### PR DESCRIPTION
Discovered in Fedora QA with PHP 7.2.0RC4
https://apps.fedoraproject.org/koschei/package/php-zendframework-zend-inputfilter?collection=f28

`PHP Fatal error:  Declaration of Zend\InputFilter\CollectionInputFilter::isValid() must be compatible with Zend\InputFilter\BaseInputFilter::isValid($context = NULL) in /builddir/build/BUILDROOT/php-zendframework-zend-inputfilter-2.7.4-2.fc28.noarch/usr/share/php/Zend/InputFilter/CollectionInputFilter.php on line 296
`