### PR TITLE
Do not re-inject filter/validator chains of inputs pulled from plugin manager

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -189,10 +189,10 @@ class Factory
             ));
         }
 
-        if ($this->defaultFilterChain) {
+        if (! $managerInstance && $this->defaultFilterChain) {
             $input->setFilterChain(clone $this->defaultFilterChain);
         }
-        if ($this->defaultValidatorChain) {
+        if (! $managerInstance && $this->defaultValidatorChain) {
             $input->setValidatorChain(clone $this->defaultValidatorChain);
         }
 


### PR DESCRIPTION
As reported in #8, a change in #2 now causes inputs pulled from the plugin manager within `Factory::createInput()` to be injected with the default filter and validator chains composed in the `Factory`.  This can cause filter and validator chains created during construction or within the input's factory to be overwritten entirely.

This patch adds conditions to skip injection of the default filter and validator chains on inputs pulled from the input filter manager, while retaining the logic introduced in #2 to allow values in the `$inputSpecification` to further configure the instance.

Fixes #8.