### PR TITLE
Ensure filter and validator chains receive default plugin managers

### DIFF
--- a/src/CollectionInputFilter.php
+++ b/src/CollectionInputFilter.php
@@ -166,8 +166,9 @@ class CollectionInputFilter extends InputFilter
 
     /**
      * {@inheritdoc}
+     * @param mixed $context Ignored, but present to retain signature compatibility.
      */
-    public function isValid()
+    public function isValid($context = null)
     {
         $this->collectionMessages = [];
         $inputFilter = $this->getInputFilter();

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -189,12 +189,9 @@ class Factory
             ));
         }
 
-        if (! $managerInstance && $this->defaultFilterChain) {
-            $input->setFilterChain(clone $this->defaultFilterChain);
-        }
-        if (! $managerInstance && $this->defaultValidatorChain) {
-            $input->setValidatorChain(clone $this->defaultValidatorChain);
-        }
+        $managerInstance
+            ? $this->injectFilterAndValidatorChainsWithPluginManagers($input)
+            : $this->injectDefaultFilterAndValidatorChains($input);
 
         foreach ($inputSpecification as $key => $value) {
             switch ($key) {
@@ -432,6 +429,49 @@ class Factory
             throw new Exception\RuntimeException(
                 'Invalid validator specification provided; was neither a validator instance nor an array specification'
             );
+        }
+    }
+
+    /**
+     * Inject the default filter and validator chains into the input, if present.
+     *
+     * This ensures custom plugins are made available to the input instance.
+     *
+     * @param InputInterface $input
+     * @return void
+     */
+    protected function injectDefaultFilterAndValidatorChains(InputInterface $input)
+    {
+        if ($this->defaultFilterChain) {
+            $input->setFilterChain(clone $this->defaultFilterChain);
+        }
+
+        if ($this->defaultValidatorChain) {
+            $input->setValidatorChain(clone $this->defaultValidatorChain);
+        }
+    }
+
+    /**
+     * Inject filter and validator chains with the plugin managers from
+     * the default chains, if present.
+     *
+     * This ensures custom plugins are made available to the input instance.
+     *
+     * @param InputInterface $input
+     * @return void
+     */
+    protected function injectFilterAndValidatorChainsWithPluginManagers(InputInterface $input)
+    {
+        if ($this->defaultFilterChain) {
+            $input->getFilterChain()
+                ? $input->getFilterChain()->setPluginManager($this->defaultFilterChain->getPluginManager())
+                : $input->setFilterChain(clone $this->defaultFilterChain);
+        }
+
+        if ($this->defaultValidatorChain) {
+            $input->getValidatorChain()
+                ? $input->getValidatorChain()->setPluginManager($this->defaultValidatorChain->getPluginManager())
+                : $input->setValidatorChain(clone $this->defaultValidatorChain);
         }
     }
 }

--- a/test/CollectionInputFilterTest.php
+++ b/test/CollectionInputFilterTest.php
@@ -19,7 +19,7 @@ use Zend\InputFilter\Exception\InvalidArgumentException;
 use Zend\InputFilter\Exception\RuntimeException;
 use Zend\InputFilter\Input;
 use Zend\InputFilter\InputFilter;
-use Zend\Validator\EmailAddress;
+use Zend\Validator\Digits;
 use Zend\Validator\NotEmpty;
 
 /**
@@ -512,10 +512,10 @@ class CollectionInputFilterTest extends TestCase
     {
         $inputFilter = new InputFilter();
         $inputFilter->add([
-            'name' => 'email',
+            'name' => 'phone',
             'required' => true,
             'validators' => [
-                ['name' => EmailAddress::class],
+                ['name' => Digits::class],
                 ['name' => NotEmpty::class],
             ],
         ]);
@@ -535,7 +535,7 @@ class CollectionInputFilterTest extends TestCase
                 'name' => 'Tom',
             ],
             [
-                'email' => 'tom@tom',
+                'phone' => 'tom@tom',
                 'name' => 'Tom',
             ],
         ]);
@@ -547,16 +547,14 @@ class CollectionInputFilterTest extends TestCase
         $this->assertFalse($isValid);
         $this->assertCount(2, $messages);
 
-        $this->assertArrayHasKey('email', $messages[0]);
-        $this->assertCount(1, $messages[0]['email']);
-        $this->assertContains('Value is required and can\'t be empty', $messages[0]['email']);
+        $this->assertArrayHasKey('phone', $messages[0]);
+        $this->assertCount(1, $messages[0]['phone']);
+        $this->assertContains('Value is required and can\'t be empty', $messages[0]['phone']);
 
-        $this->assertArrayHasKey('email', $messages[1]);
-        $this->assertCount(3, $messages[1]['email']);
-        $this->assertNotContains('Value is required and can\'t be empty', $messages[1]['email']);
-        $this->assertContains('\'tom\' is not a valid hostname for the email address', $messages[1]['email']);
-        $this->assertContains('The input does not match the expected structure for a DNS hostname', $messages[1]['email']);
-        $this->assertContains('The input appears to be a local network name but local network names are not allowed', $messages[1]['email']);
+        $this->assertArrayHasKey('phone', $messages[1]);
+        $this->assertCount(1, $messages[1]['phone']);
+        $this->assertNotContains('Value is required and can\'t be empty', $messages[1]['phone']);
+        $this->assertContains('The input must contain only digits', $messages[1]['phone']);
         // @codingStandardsIgnoreEnd
     }
 
@@ -564,10 +562,10 @@ class CollectionInputFilterTest extends TestCase
     {
         $inputFilter = new InputFilter();
         $inputFilter->add([
-            'name' => 'email',
+            'name' => 'phone',
             'required' => true,
             'validators' => [
-                ['name' => EmailAddress::class],
+                ['name' => Digits::class],
                 ['name' => NotEmpty::class],
             ],
             'error_message' => 'CUSTOM ERROR MESSAGE',
@@ -588,7 +586,7 @@ class CollectionInputFilterTest extends TestCase
                 'name' => 'Tom',
             ],
             [
-                'email' => 'tom@tom',
+                'phone' => 'tom@tom',
                 'name' => 'Tom',
             ],
         ]);
@@ -600,14 +598,14 @@ class CollectionInputFilterTest extends TestCase
         $this->assertFalse($isValid);
         $this->assertCount(2, $messages);
 
-        $this->assertArrayHasKey('email', $messages[0]);
-        $this->assertCount(1, $messages[0]['email']);
-        $this->assertContains('CUSTOM ERROR MESSAGE', $messages[0]['email']);
-        $this->assertNotContains('Value is required and can\'t be empty', $messages[0]['email']);
+        $this->assertArrayHasKey('phone', $messages[0]);
+        $this->assertCount(1, $messages[0]['phone']);
+        $this->assertContains('CUSTOM ERROR MESSAGE', $messages[0]['phone']);
+        $this->assertNotContains('Value is required and can\'t be empty', $messages[0]['phone']);
 
-        $this->assertArrayHasKey('email', $messages[1]);
-        $this->assertCount(1, $messages[1]['email']);
-        $this->assertContains('CUSTOM ERROR MESSAGE', $messages[1]['email']);
+        $this->assertArrayHasKey('phone', $messages[1]);
+        $this->assertCount(1, $messages[1]['phone']);
+        $this->assertContains('CUSTOM ERROR MESSAGE', $messages[1]['phone']);
     }
 
     public function testDuplicatedErrorMessages()


### PR DESCRIPTION
Per #155, When using the factory, particularly with the `InputFilterAbstractServiceFactory`, the plugin managers used with the default filter and validator chains should be used with all newly created inputs, as these will have any custom services registered (vs. those that are in the initially created inputs, which are unconfigured).

This means that:

- For cases where the instance was pulled from the `InputFilterManager`, we need to inject the filter and validator chains with the plugin managers pulled from the default instances; if the chain does not exist, we clone the default instance.
- For other instances, we need to simply clone the default filter and validator chains (which are empty, but have the configured filter and validator plugin managers).

This patch also contains two unrelated fixes, but they are included so that the test suite will actually pass under PHP 7.2:

- An update to the `CollectionInputFilter::isValid` signature to match that of `InputFilterInterface::isValid`.
- An update to some tests that used the `EmailAddress` validator; this validator uses constants deprecated in PHP 7.2, which raised errors during testing. These have each been updated to use the Digits validator instead, which is fully compatible.

Fixes #155.