### PR TITLE
Fix invalid abstract service factory configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#129](https://github.com/zendframework/zend-inputfilter/pull/129) fixes
+  incorrect abstract service factory registration in `ConfigProvider`as per
+  the [latest documentation](https://docs.zendframework.com/zend-inputfilter/specs/#setup).
 
 ## 2.8.1 - 2018-01-22
 

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -18,6 +18,7 @@ class ConfigProvider
     {
         return [
             'dependencies' => $this->getDependencyConfig(),
+            'input_filters' => $this->getInputFilterConfig(),
         ];
     }
 
@@ -32,11 +33,22 @@ class ConfigProvider
             'aliases' => [
                 'InputFilterManager' => InputFilterPluginManager::class,
             ],
-            'abstract_factories' => [
-                InputFilterAbstractServiceFactory::class,
-            ],
             'factories' => [
                 InputFilterPluginManager::class => InputFilterPluginManagerFactory::class,
+            ],
+        ];
+    }
+
+    /**
+     * Get input filter configuration
+     *
+     * @return array
+     */
+    public function getInputFilterConfig()
+    {
+        return [
+            'abstract_factories' => [
+                InputFilterAbstractServiceFactory::class,
             ],
         ];
     }

--- a/test/ConfigProviderTest.php
+++ b/test/ConfigProviderTest.php
@@ -20,9 +20,6 @@ final class ConfigProviderTest extends TestCase
         $provider = new ConfigProvider();
 
         $expected = [
-            'abstract_factories' => [
-                InputFilterAbstractServiceFactory::class,
-            ],
             'aliases' => [
                 'InputFilterManager' => InputFilterPluginManager::class,
             ],
@@ -34,12 +31,26 @@ final class ConfigProviderTest extends TestCase
         $this->assertEquals($expected, $provider->getDependencyConfig());
     }
 
+    public function testProvidesExpectedInputFilterConfiguration()
+    {
+        $provider = new ConfigProvider();
+
+        $expected = [
+            'abstract_factories' => [
+                InputFilterAbstractServiceFactory::class,
+            ],
+        ];
+
+        $this->assertEquals($expected, $provider->getInputFilterConfig());
+    }
+
     public function testInvocationProvidesDependencyConfiguration()
     {
         $provider = new ConfigProvider();
 
         $expected = [
             'dependencies' => $provider->getDependencyConfig(),
+            'input_filters' => $provider->getInputFilterConfig(),
         ];
         $this->assertEquals($expected, $provider());
     }


### PR DESCRIPTION
This fixes #129.

Registration of `InputFilterAbstractServiceFactory` is currently invalid in `ConfigProvider`. Instead of the `abstract_factories` key being nested under `dependencies` it should be nested under `input_filters`.

This pull request corrects the behaviour and allows using the service with no manual changes required when using the library in a Zend Expressive project.

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
  - [x] Detail the original, incorrect behavior.
  - [x] Detail the new, expected behavior.
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [ ] Add a regression test that demonstrates the bug, and proves the fix.
  Is this really needed? I've included tests that validate the current (correct) behaviour.
  - [x] Add a `CHANGELOG.md` entry for the fix.
