### PR TITLE
Hotfix/non iterable inputfilter value

### DIFF
--- a/src/BaseInputFilter.php
+++ b/src/BaseInputFilter.php
@@ -178,15 +178,22 @@ class BaseInputFilter implements
      */
     public function setData($data)
     {
+        // A null value indicates an empty set
+        if (null === $data) {
+            $data = [];
+        }
+
         if ($data instanceof Traversable) {
             $data = ArrayUtils::iteratorToArray($data);
         }
 
-        // A null value indicates an empty set
-        if (null === $data || ! is_array($data)) {
-            $data = [];
+        if (! is_array($data)) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                '%s expects an array or Traversable argument; received %s',
+                __METHOD__,
+                (is_object($data) ? get_class($data) : gettype($data))
+            ));
         }
-
         $this->data = $data;
         $this->populate();
         return $this;
@@ -516,6 +523,14 @@ class BaseInputFilter implements
             $value = $this->data[$name];
 
             if ($input instanceof InputFilterInterface) {
+                if ($value instanceof Traversable) {
+                    $value = ArrayUtils::iteratorToArray($value);
+                }
+
+                if (! is_array($value)) {
+                    $value = [];
+                }
+
                 $input->setData($value);
                 continue;
             }

--- a/src/BaseInputFilter.php
+++ b/src/BaseInputFilter.php
@@ -523,11 +523,8 @@ class BaseInputFilter implements
             $value = $this->data[$name];
 
             if ($input instanceof InputFilterInterface) {
-                if ($value instanceof Traversable) {
-                    $value = ArrayUtils::iteratorToArray($value);
-                }
-
-                if (! is_array($value)) {
+                // Fixes #159
+                if (! is_array($value) && !$value instanceof Traversable) {
                     $value = [];
                 }
 

--- a/src/BaseInputFilter.php
+++ b/src/BaseInputFilter.php
@@ -178,22 +178,15 @@ class BaseInputFilter implements
      */
     public function setData($data)
     {
-        // A null value indicates an empty set
-        if (null === $data) {
-            $data = [];
-        }
-
         if ($data instanceof Traversable) {
             $data = ArrayUtils::iteratorToArray($data);
         }
 
-        if (! is_array($data)) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s expects an array or Traversable argument; received %s',
-                __METHOD__,
-                (is_object($data) ? get_class($data) : gettype($data))
-            ));
+        // A null value indicates an empty set
+        if (null === $data || ! is_array($data)) {
+            $data = [];
         }
+
         $this->data = $data;
         $this->populate();
         return $this;

--- a/src/BaseInputFilter.php
+++ b/src/BaseInputFilter.php
@@ -524,7 +524,7 @@ class BaseInputFilter implements
 
             if ($input instanceof InputFilterInterface) {
                 // Fixes #159
-                if (! is_array($value) && !$value instanceof Traversable) {
+                if (! is_array($value) && ! $value instanceof Traversable) {
                     $value = [];
                 }
 

--- a/test/BaseInputFilterTest.php
+++ b/test/BaseInputFilterTest.php
@@ -106,6 +106,16 @@ class BaseInputFilterTest extends TestCase
         $inputFilter->getRawValue('not exists');
     }
 
+    public function testSetDataWithInvalidDataTypeThrowsInvalidArgumentException()
+    {
+        $inputFilter = $this->inputFilter;
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('expects an array or Traversable argument; received stdClass');
+        /** @noinspection PhpParamsInspection */
+        $inputFilter->setData(new stdClass());
+    }
+
     public function testIsValidThrowExceptionIfDataWasNotSetYet()
     {
         $inputFilter = $this->inputFilter;

--- a/test/BaseInputFilterTest.php
+++ b/test/BaseInputFilterTest.php
@@ -106,6 +106,15 @@ class BaseInputFilterTest extends TestCase
         $inputFilter->getRawValue('not exists');
     }
 
+    public function testIsValidThrowExceptionIfDataWasNotSetYet()
+    {
+        $inputFilter = $this->inputFilter;
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('no data present to validate');
+        $inputFilter->isValid();
+    }
+
     public function testSetValidationGroupSkipsRecursionWhenInputIsNotAnInputFilter()
     {
         $inputFilter = $this->inputFilter;

--- a/test/BaseInputFilterTest.php
+++ b/test/BaseInputFilterTest.php
@@ -585,6 +585,24 @@ class BaseInputFilterTest extends TestCase
         );
     }
 
+    public function testNestedInputFilterShouldAllowNonArrayValueForData()
+    {
+        $filter1 = new BaseInputFilter();
+        $nestedFilter = new BaseInputFilter();
+        $nestedFilter->add(new Input('nestedField1'));
+        $filter1->add($nestedFilter, 'nested');
+
+        // non scalar and non null value
+        $filter1->setData(['nested' => false]);
+        self::assertNull($filter1->getValues()['nested']['nestedField1']);
+
+        $filter1->setData(['nested' => 123]);
+        self::assertNull($filter1->getValues()['nested']['nestedField1']);
+
+        $filter1->setData(['nested' => new stdClass()]);
+        self::assertNull($filter1->getValues()['nested']['nestedField1']);
+    }
+
     public function addMethodArgumentsProvider()
     {
         $inputTypes = $this->inputProvider();

--- a/test/BaseInputFilterTest.php
+++ b/test/BaseInputFilterTest.php
@@ -106,25 +106,6 @@ class BaseInputFilterTest extends TestCase
         $inputFilter->getRawValue('not exists');
     }
 
-    public function testSetDataWithInvalidDataTypeThrowsInvalidArgumentException()
-    {
-        $inputFilter = $this->inputFilter;
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('expects an array or Traversable argument; received stdClass');
-        /** @noinspection PhpParamsInspection */
-        $inputFilter->setData(new stdClass());
-    }
-
-    public function testIsValidThrowExceptionIfDataWasNotSetYet()
-    {
-        $inputFilter = $this->inputFilter;
-
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('no data present to validate');
-        $inputFilter->isValid();
-    }
-
     public function testSetValidationGroupSkipsRecursionWhenInputIsNotAnInputFilter()
     {
         $inputFilter = $this->inputFilter;

--- a/test/InputFilterTest.php
+++ b/test/InputFilterTest.php
@@ -126,24 +126,4 @@ class InputFilterTest extends BaseInputFilterTest
         $filter1->setData(['nested' => new stdClass()]);
         self::assertNull($filter1->getValues()['nested']['nestedField1']);
     }
-
-    public function testInputFilterShouldAllowNonArrayValueForData() {
-        $filter1 = new InputFilter();
-        $filter1->add([
-            'type' => Input::class,
-            'required' => true
-        ], 'filter');
-
-        // non scalar and non null value
-        $filter1->setData(false);
-        self::assertNull($filter1->getValues()['filter']);
-
-        $filter1->setData(['nested' => 123]);
-        self::assertNull($filter1->getValues()['filter']);
-
-        $filter1->setData(['nested' => new stdClass()]);
-        self::assertNull($filter1->getValues()['filter']);
-    }
-
-
 }

--- a/test/InputFilterTest.php
+++ b/test/InputFilterTest.php
@@ -105,25 +105,4 @@ class InputFilterTest extends BaseInputFilterTest
         $filter1->setData(['nested' => null]);
         self::assertNull($filter1->getValues()['nested']['nestedField1']);
     }
-
-    public function testNestedInputFilterShouldAllowNonArrayValueForData()
-    {
-        $filter1 = new InputFilter();
-        $filter1->add([
-            'type' => InputFilter::class,
-            'nestedField1' => [
-                'required' => false
-            ]
-        ], 'nested');
-
-        // non scalar and non null value
-        $filter1->setData(['nested' => false]);
-        self::assertNull($filter1->getValues()['nested']['nestedField1']);
-
-        $filter1->setData(['nested' => 123]);
-        self::assertNull($filter1->getValues()['nested']['nestedField1']);
-
-        $filter1->setData(['nested' => new stdClass()]);
-        self::assertNull($filter1->getValues()['nested']['nestedField1']);
-    }
 }

--- a/test/InputFilterTest.php
+++ b/test/InputFilterTest.php
@@ -11,6 +11,7 @@ namespace ZendTest\InputFilter;
 
 use ArrayIterator;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use stdClass;
 use Zend\InputFilter\Factory;
 use Zend\InputFilter\Input;
 use Zend\InputFilter\InputFilter;
@@ -104,4 +105,45 @@ class InputFilterTest extends BaseInputFilterTest
         $filter1->setData(['nested' => null]);
         self::assertNull($filter1->getValues()['nested']['nestedField1']);
     }
+
+    public function testNestedInputFilterShouldAllowNonArrayValueForData()
+    {
+        $filter1 = new InputFilter();
+        $filter1->add([
+            'type' => InputFilter::class,
+            'nestedField1' => [
+                'required' => false
+            ]
+        ], 'nested');
+
+        // non scalar and non null value
+        $filter1->setData(['nested' => false]);
+        self::assertNull($filter1->getValues()['nested']['nestedField1']);
+
+        $filter1->setData(['nested' => 123]);
+        self::assertNull($filter1->getValues()['nested']['nestedField1']);
+
+        $filter1->setData(['nested' => new stdClass()]);
+        self::assertNull($filter1->getValues()['nested']['nestedField1']);
+    }
+
+    public function testInputFilterShouldAllowNonArrayValueForData() {
+        $filter1 = new InputFilter();
+        $filter1->add([
+            'type' => Input::class,
+            'required' => true
+        ], 'filter');
+
+        // non scalar and non null value
+        $filter1->setData(false);
+        self::assertNull($filter1->getValues()['filter']);
+
+        $filter1->setData(['nested' => 123]);
+        self::assertNull($filter1->getValues()['filter']);
+
+        $filter1->setData(['nested' => new stdClass()]);
+        self::assertNull($filter1->getValues()['filter']);
+    }
+
+
 }


### PR DESCRIPTION
Fixes issue #159 

Currently, when you send a non-iterable value, non-null value to a nested input filter, it incorrectly raises an InvalidArgumentException. It should report as if all underlying fields are empty, and treat the value as an empty array.