### PR TITLE
Required does not work, when array is empty

### DIFF
--- a/src/ArrayInput.php
+++ b/src/ArrayInput.php
@@ -83,6 +83,14 @@ class ArrayInput extends Input
         $validator = $this->getValidatorChain();
         $values    = $this->getValue();
         $result    = true;
+        
+        if ($required && empty($values)) {
+            if ($this->errorMessage === null) {
+                $this->errorMessage = $this->prepareRequiredValidationFailureMessage();
+            }
+            return false;
+        }
+        
         foreach ($values as $value) {
             $empty = ($value === null || $value === '' || $value === []);
             if ($empty && ! $this->isRequired() && ! $this->continueIfEmpty()) {

--- a/src/ArrayInput.php
+++ b/src/ArrayInput.php
@@ -83,14 +83,14 @@ class ArrayInput extends Input
         $validator = $this->getValidatorChain();
         $values    = $this->getValue();
         $result    = true;
-        
+
         if ($required && empty($values)) {
             if ($this->errorMessage === null) {
                 $this->errorMessage = $this->prepareRequiredValidationFailureMessage();
             }
             return false;
         }
-        
+
         foreach ($values as $value) {
             $empty = ($value === null || $value === '' || $value === []);
             if ($empty && ! $this->isRequired() && ! $this->continueIfEmpty()) {

--- a/test/ArrayInputTest.php
+++ b/test/ArrayInputTest.php
@@ -26,7 +26,7 @@ class ArrayInputTest extends InputTest
     {
         $this->assertCount(0, $this->input->getValue());
     }
-    
+
     public function testRequiredWithoutFallbackAndValueIsEmptyArrayThenFail()
     {
         $input = $this->input;

--- a/test/ArrayInputTest.php
+++ b/test/ArrayInputTest.php
@@ -32,10 +32,9 @@ class ArrayInputTest extends InputTest
         $input = $this->input;
         $input->setRequired(true);
         $input->setValue([]);
-        
         $this->assertFalse(
             $input->isValid(),
-            'isValid() should be return always false when no fallback value, is required, and not data is set.'
+            'isValid() should be return always false when no fallback value, is required, and value is empty array.'
         );
         $this->assertRequiredValidationErrorMessage($input);
     }

--- a/test/ArrayInputTest.php
+++ b/test/ArrayInputTest.php
@@ -26,6 +26,19 @@ class ArrayInputTest extends InputTest
     {
         $this->assertCount(0, $this->input->getValue());
     }
+    
+    public function testRequiredWithoutFallbackAndValueIsEmptyArrayThenFail()
+    {
+        $input = $this->input;
+        $input->setRequired(true);
+        $input->setValue([]);
+        
+        $this->assertFalse(
+            $input->isValid(),
+            'isValid() should be return always false when no fallback value, is required, and not data is set.'
+        );
+        $this->assertRequiredValidationErrorMessage($input);
+    }
 
     public function testSetValueWithInvalidInputTypeThrowsInvalidArgumentException()
     {


### PR DESCRIPTION
The first problem is, that hasValue always returns true, when a value is set, even, if the value is an empty array. So the first validation for the required filter will be skipped. The second problem is, that the isRequired is called within the foreach loop. But if the value is an empty array, the loop will never start, so isRequired will never triggered and the method will return the defaultValue true.
