### PR TITLE
Fix regression introduced in 2.9.0 when overriding FileUpload default validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,14 +22,15 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#175](https://github.com/zendframework/zend-inputfilter/pull/175) fixes a regression introduced in 2.9.0 when
+  overriding FileUpload default validator.
 
 ## 2.9.0 - 2018-12-17
 
 ### Added
 
 - [#172](https://github.com/zendframework/zend-inputfilter/pull/172) adds support for PSR-7 `UploadedFileInterface` to `Zend\InputFilter\FileInput`.
-  It adds a new interface, `Zend\InputFilter\FileInput\FileInputDecoratorInterface`, 
+  It adds a new interface, `Zend\InputFilter\FileInput\FileInputDecoratorInterface`,
   which defines methods required for validating and filtering file uploads. It
   also provides two implementations of it, one for standard SAPI file uploads,
   and the other for PSR-7 uploads. The `FileInput` class does detection on the

--- a/src/FileInput/HttpServerFileInputDecorator.php
+++ b/src/FileInput/HttpServerFileInputDecorator.php
@@ -153,7 +153,7 @@ class HttpServerFileInputDecorator extends FileInput implements FileInputDecorat
             return $chain;
         }
 
-        $chain->prependByName(UploadValidator::class, [], true);
+        $chain->prependByName('fileuploadfile', [], true);
         $this->subject->autoPrependUploadValidator = false;
 
         return $chain;

--- a/test/FileInput/HttpServerFileInputDecoratorTest.php
+++ b/test/FileInput/HttpServerFileInputDecoratorTest.php
@@ -272,6 +272,17 @@ class HttpServerFileInputDecoratorTest extends InputTest
         $this->assertFalse($this->input->isEmptyFile($rawValue));
     }
 
+    public function testDefaultInjectedUploadValidatorRespectsRelease2Convention()
+    {
+        $input = new FileInput('foo');
+        $validatorChain = $input->getValidatorChain();
+        $pluginManager = $validatorChain->getPluginManager();
+        $pluginManager->setInvokableClass('fileuploadfile', TestAsset\FileUploadMock::class);
+        $input->setValue('');
+
+        $this->assertTrue($input->isValid());
+    }
+
     /**
      * Specific FileInput::merge extras
      */

--- a/test/FileInput/TestAsset/FileUploadMock.php
+++ b/test/FileInput/TestAsset/FileUploadMock.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-inputfilter for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-inputfilter/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\InputFilter\FileInput\TestAsset;
+
+use Zend\Validator\ValidatorInterface;
+
+final class FileUploadMock implements ValidatorInterface
+{
+    public function isValid($value)
+    {
+        return true;
+    }
+
+    public function getMessages()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
https://github.com/zendframework/zend-inputfilter/pull/172 introduced a BC Break: till release-2.8.3 the default validator was set as alias `'fileuploadfile'`. In a functional test environment it must be overridden, and thus until version 3 the alias used must be kept `'fileuploadfile'`.

https://github.com/zendframework/zend-inputfilter/blob/799ad48ed1666d3c62126fec73dd20453b3a9e4d/src/FileInput.php#L190-L192