### PR TITLE
Feature/unfiltered input data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ clover.xml
 coveralls-upload.json
 phpunit.xml
 zf-mkdoc-theme.tgz
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ clover.xml
 coveralls-upload.json
 phpunit.xml
 zf-mkdoc-theme.tgz
-.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,18 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- Nothing.
+- [#176](https://github.com/zendframework/zend-inputfilter/pull/176) adds the interface `UnfilteredDataInterface`, with the following methods:
+
+  ```php
+  public function getUnfilteredData() : array|object;
+  public function setUnfilteredData(array|object $data) : $this;
+  ```
+
+  By default, the `BaseInputFilter` now implements this interface.
+
+  The primary purpose of the interface is to allow the ability to access ALL
+  original raw data, and not just the data the input filter knows about. This is
+  particularly useful with collections.
 
 ### Changed
 

--- a/docs/book/unfiltered-data.md
+++ b/docs/book/unfiltered-data.md
@@ -1,0 +1,49 @@
+# Unfiltered Data
+
+> Since 2.10.0
+
+On input filters, there are several methods for retrieving the data:
+
+- `getValues()` will return all known values after filtering them.
+- `getRawValues()` will return all known values with no filtering applied.
+- `getUnknown()` returns the set of all unknown values (values with no
+  corresponding input or input filter).
+
+At times, particularly when working with collections, you may want access to the
+complete set of original data provided to the input filter. This can be
+accomplished by merging the sets returned by `getRawValues()` and
+`getUnknown()` when working with normal input filters, but this approach breaks
+down when working with collections.
+
+Version 2.10.0 introduces a new interface, `Zend\InputFilter\UnfilteredDataInterface`,
+for dealing with this situation. `Zend\InputFilter\BaseInputFilter`, which
+forms the parent class for all shipped input filter implementations, implements
+the interface, which consists of the following methods:
+
+```php
+interface UnfilteredDataInterface
+{
+    /**
+     * @return array|object
+     */
+    public function getUnfilteredData()
+    {
+        return $this->unfilteredData;
+    }
+
+    /**
+     * @param array|object $data
+     * @return $this
+     */
+    public function setUnfilteredData($data)
+    {
+        $this->unfilteredData = $data;
+        return $this;
+    }
+}
+```
+
+The `setUnfilteredData()` method is called by `setData()` with the full `$data`
+provided to that method, ensuring that `getUnfilteredData()` will always provide
+the original data with which the input filter was initialized, with no filtering
+applied.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,13 +1,14 @@
 docs_dir: docs/book
 site_dir: docs/html
 pages:
-    - index.md
-    - Intro: intro.md
+    - Home: index.md
+    - Introduction: intro.md
     - Reference:
       - Specifications: specs.md
       - Files: file-input.md
       - "Optional Input Filters": optional-input-filters.md
+      - "Unfiltered Data": unfiltered-data.md
 site_name: zend-inputfilter
 site_description: zend-inputfilter
 repo_url: 'https://github.com/zendframework/zend-inputfilter'
-copyright: 'Copyright (c) 2016-2017 <a href="http://www.zend.com/">Zend Technologies USA Inc.</a>'
+copyright: 'Copyright (c) 2016-2019 <a href="http://www.zend.com/">Zend Technologies USA Inc.</a>'

--- a/src/BaseInputFilter.php
+++ b/src/BaseInputFilter.php
@@ -11,6 +11,7 @@ namespace Zend\InputFilter;
 
 use ArrayAccess;
 use Traversable;
+use TypeError;
 use Zend\Stdlib\ArrayUtils;
 use Zend\Stdlib\InitializableInterface;
 
@@ -25,6 +26,11 @@ class BaseInputFilter implements
      * @var null|array
      */
     protected $data;
+
+    /**
+     * @var array
+     */
+    protected $unfilteredData = [];
 
     /**
      * @var InputInterface[]|InputFilterInterface[]
@@ -604,17 +610,27 @@ class BaseInputFilter implements
         return $this;
     }
 
+    /**
+     * @return array
+     */
     // TODO replace functions when upgrading to > PHP 7.2 as minimum requirement
     //    public function getUnfilteredData() : array;
     public function getUnfilteredData()
     {
-        return [];
+        return $this->unfilteredData;
     }
 
+    /**
+     * @param array $data
+     *
+     * @return $this
+     */
     // TODO replace functions when upgrading to > PHP 7.2 as minimum requirement
-    //    public function setUnfilteredData(array $data) : array;
+    //    public function setUnfilteredData(array $data) : UnfilteredDataInterface;
     public function setUnfilteredData($data)
     {
+        $this->unfilteredData = $data;
+
         return $this;
     }
 }

--- a/src/BaseInputFilter.php
+++ b/src/BaseInputFilter.php
@@ -608,13 +608,13 @@ class BaseInputFilter implements
     //    public function getUnfilteredData() : array;
     public function getUnfilteredData()
     {
-        // TODO: Implement getUnfilteredData() method.
+        return [];
     }
 
     // TODO replace functions when upgrading to > PHP 7.2 as minimum requirement
     //    public function setUnfilteredData(array $data) : array;
     public function setUnfilteredData($data)
     {
-        // TODO: Implement setUnfilteredData() method.
+        return $this;
     }
 }

--- a/src/BaseInputFilter.php
+++ b/src/BaseInputFilter.php
@@ -616,8 +616,6 @@ class BaseInputFilter implements
     /**
      * @return array
      */
-    // TODO replace functions when upgrading to > PHP 7.2 as minimum requirement
-    //    public function getUnfilteredData() : array;
     public function getUnfilteredData()
     {
         return $this->unfilteredData;
@@ -628,8 +626,6 @@ class BaseInputFilter implements
      *
      * @return $this
      */
-    // TODO replace functions when upgrading to > PHP 7.2 as minimum requirement
-    //    public function setUnfilteredData(array $data) : UnfilteredDataInterface;
     public function setUnfilteredData($data)
     {
         $this->unfilteredData = $data;

--- a/src/BaseInputFilter.php
+++ b/src/BaseInputFilter.php
@@ -18,7 +18,8 @@ class BaseInputFilter implements
     InputFilterInterface,
     UnknownInputsCapableInterface,
     InitializableInterface,
-    ReplaceableInputInterface
+    ReplaceableInputInterface,
+    UnfilteredDataInterface
 {
     /**
      * @var null|array
@@ -601,5 +602,19 @@ class BaseInputFilter implements
         }
 
         return $this;
+    }
+
+    // TODO replace functions when upgrading to > PHP 7.2 as minimum requirement
+    //    public function getUnfilteredData() : array;
+    public function getUnfilteredData()
+    {
+        // TODO: Implement getUnfilteredData() method.
+    }
+
+    // TODO replace functions when upgrading to > PHP 7.2 as minimum requirement
+    //    public function setUnfilteredData(array $data) : array;
+    public function setUnfilteredData($data)
+    {
+        // TODO: Implement setUnfilteredData() method.
     }
 }

--- a/src/BaseInputFilter.php
+++ b/src/BaseInputFilter.php
@@ -3,7 +3,7 @@
  * Zend Framework (http://framework.zend.com/)
  *
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2005-2019 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
@@ -11,7 +11,6 @@ namespace Zend\InputFilter;
 
 use ArrayAccess;
 use Traversable;
-use TypeError;
 use Zend\Stdlib\ArrayUtils;
 use Zend\Stdlib\InitializableInterface;
 
@@ -201,8 +200,12 @@ class BaseInputFilter implements
                 (is_object($data) ? get_class($data) : gettype($data))
             ));
         }
+
+        $this->setUnfilteredData($data);
+
         $this->data = $data;
         $this->populate();
+
         return $this;
     }
 

--- a/src/BaseInputFilter.php
+++ b/src/BaseInputFilter.php
@@ -27,7 +27,7 @@ class BaseInputFilter implements
     protected $data;
 
     /**
-     * @var array
+     * @var array|object
      */
     protected $unfilteredData = [];
 
@@ -614,7 +614,7 @@ class BaseInputFilter implements
     }
 
     /**
-     * @return array
+     * @return array|object
      */
     public function getUnfilteredData()
     {
@@ -622,14 +622,12 @@ class BaseInputFilter implements
     }
 
     /**
-     * @param array $data
-     *
+     * @param array|object $data
      * @return $this
      */
     public function setUnfilteredData($data)
     {
         $this->unfilteredData = $data;
-
         return $this;
     }
 }

--- a/src/CollectionInputFilter.php
+++ b/src/CollectionInputFilter.php
@@ -153,6 +153,8 @@ class CollectionInputFilter extends InputFilter
             ));
         }
 
+        $this->setUnfilteredData($data);
+
         foreach ($data as $item) {
             if (is_array($item) || $item instanceof Traversable) {
                 continue;

--- a/src/UnfilteredDataInterface.php
+++ b/src/UnfilteredDataInterface.php
@@ -3,7 +3,7 @@
  * Zend Framework (http://framework.zend.com/)
  *
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2005-2019 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 

--- a/src/UnfilteredDataInterface.php
+++ b/src/UnfilteredDataInterface.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2019 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @see       https://github.com/zendframework/zend-inputfilter for the canonical source repository
+ * @copyright Copyright (c) 2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-inputfilter/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\InputFilter;

--- a/src/UnfilteredDataInterface.php
+++ b/src/UnfilteredDataInterface.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\InputFilter;
+
+/**
+ * Ensures Inputs store unfiltered data and are capable of returning it
+ */
+interface UnfilteredDataInterface
+{
+    /**
+     * @return array
+     */
+    public function getUnfilteredData();
+
+    /**
+     * @param array  $data
+     *
+     * @return array
+     */
+    public function setUnfilteredData($data);
+
+    // TODO replace functions when upgrading to > PHP 7.2 as minimum requirement
+    //    public function getUnfilteredData() : array;
+    //    public function setUnfilteredData(array $data) : array;
+}

--- a/src/UnfilteredDataInterface.php
+++ b/src/UnfilteredDataInterface.php
@@ -25,8 +25,4 @@ interface UnfilteredDataInterface
      * @return array
      */
     public function setUnfilteredData($data);
-
-    // TODO replace functions when upgrading to > PHP 7.2 as minimum requirement
-    //    public function getUnfilteredData() : array;
-    //    public function setUnfilteredData(array $data) : UnfilteredDataInterface;
 }

--- a/src/UnfilteredDataInterface.php
+++ b/src/UnfilteredDataInterface.php
@@ -28,5 +28,5 @@ interface UnfilteredDataInterface
 
     // TODO replace functions when upgrading to > PHP 7.2 as minimum requirement
     //    public function getUnfilteredData() : array;
-    //    public function setUnfilteredData(array $data) : array;
+    //    public function setUnfilteredData(array $data) : UnfilteredDataInterface;
 }

--- a/src/UnfilteredDataInterface.php
+++ b/src/UnfilteredDataInterface.php
@@ -13,14 +13,13 @@ namespace Zend\InputFilter;
 interface UnfilteredDataInterface
 {
     /**
-     * @return array
+     * @return array|object
      */
     public function getUnfilteredData();
 
     /**
-     * @param array  $data
-     *
-     * @return array
+     * @param array|object $data
+     * @return $this
      */
     public function setUnfilteredData($data);
 }

--- a/test/BaseInputFilterTest.php
+++ b/test/BaseInputFilterTest.php
@@ -653,6 +653,28 @@ class BaseInputFilterTest extends TestCase
         self::assertSame($testArray, $baseInputFilter->getUnfilteredData());
     }
 
+    public function testSetDataUsingSetDataAndApplyFiltersReturningSameAsOriginalForUnfilteredData()
+    {
+        $filteredArray = [
+            'bar' => 'foo',
+        ];
+
+        $unfilteredArray = array_merge(
+            $filteredArray,
+            [
+                'foo' => 'bar',
+            ]
+        );
+
+        /** @var BaseInputFilter $baseInputFilter */
+        $baseInputFilter = (new BaseInputFilter())
+            ->add(new Input(), 'bar')
+            ->setData($unfilteredArray);
+
+        self::assertSame($unfilteredArray, $baseInputFilter->getUnfilteredData());
+        self::assertSame($filteredArray, $baseInputFilter->getValues());
+    }
+
     public function addMethodArgumentsProvider()
     {
         $inputTypes = $this->inputProvider();

--- a/test/BaseInputFilterTest.php
+++ b/test/BaseInputFilterTest.php
@@ -615,6 +615,20 @@ class BaseInputFilterTest extends TestCase
         );
     }
 
+    public function testGetUnfilteredDataReturnsArray()
+    {
+        $baseInputFilter = new BaseInputFilter();
+
+        self::assertInternalType('array', $baseInputFilter->getUnfilteredData());
+    }
+
+    public function testSetUnfilteredDataReturnsBaseInputFilter()
+    {
+        $baseInputFilter = new BaseInputFilter();
+
+        self::assertInstanceOf(BaseInputFilter::class, $baseInputFilter->setUnfilteredData([]));
+    }
+
     public function addMethodArgumentsProvider()
     {
         $inputTypes = $this->inputProvider();

--- a/test/BaseInputFilterTest.php
+++ b/test/BaseInputFilterTest.php
@@ -641,6 +641,18 @@ class BaseInputFilterTest extends TestCase
         self::assertSame($testArray, $baseInputFilter->getUnfilteredData());
     }
 
+    public function testSettingAndReturnDataArrayUsingSetDataForUnfilteredDataInterface()
+    {
+        $testArray = [
+            'foo' => 'bar',
+        ];
+
+        $baseInputFilter = new BaseInputFilter();
+        $baseInputFilter->setData($testArray);
+
+        self::assertSame($testArray, $baseInputFilter->getUnfilteredData());
+    }
+
     public function addMethodArgumentsProvider()
     {
         $inputTypes = $this->inputProvider();

--- a/test/BaseInputFilterTest.php
+++ b/test/BaseInputFilterTest.php
@@ -12,8 +12,8 @@ namespace ZendTest\InputFilter;
 use ArrayIterator;
 use ArrayObject;
 use FilterIterator;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use PHPUnit\Framework\TestCase;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use stdClass;
 use Zend\InputFilter\BaseInputFilter;
 use Zend\InputFilter\Exception\InvalidArgumentException;
@@ -21,6 +21,7 @@ use Zend\InputFilter\Exception\RuntimeException;
 use Zend\InputFilter\Input;
 use Zend\InputFilter\InputFilterInterface;
 use Zend\InputFilter\InputInterface;
+use Zend\InputFilter\UnfilteredDataInterface;
 
 /**
  * @covers Zend\InputFilter\BaseInputFilter
@@ -601,6 +602,17 @@ class BaseInputFilterTest extends TestCase
 
         $filter1->setData(['nested' => new stdClass()]);
         self::assertNull($filter1->getValues()['nested']['nestedField1']);
+    }
+
+    public function testInstanceOfUnfilteredDataInterface()
+    {
+        $baseInputFilter = new BaseInputFilter();
+
+        self::assertInstanceOf(
+            UnfilteredDataInterface::class,
+            $baseInputFilter,
+            sprintf('%s should implement %s', BaseInputFilter::class, UnfilteredDataInterface::class)
+        );
     }
 
     public function addMethodArgumentsProvider()

--- a/test/BaseInputFilterTest.php
+++ b/test/BaseInputFilterTest.php
@@ -629,6 +629,18 @@ class BaseInputFilterTest extends TestCase
         self::assertInstanceOf(BaseInputFilter::class, $baseInputFilter->setUnfilteredData([]));
     }
 
+    public function testSettingAndReturningDataArrayUnfilteredDataInterface()
+    {
+        $testArray = [
+            'foo' => 'bar',
+        ];
+
+        $baseInputFilter = new BaseInputFilter();
+        $baseInputFilter->setUnfilteredData($testArray);
+
+        self::assertSame($testArray, $baseInputFilter->getUnfilteredData());
+    }
+
     public function addMethodArgumentsProvider()
     {
         $inputTypes = $this->inputProvider();

--- a/test/BaseInputFilterTest.php
+++ b/test/BaseInputFilterTest.php
@@ -673,6 +673,7 @@ class BaseInputFilterTest extends TestCase
 
         self::assertSame($unfilteredArray, $baseInputFilter->getUnfilteredData());
         self::assertSame($filteredArray, $baseInputFilter->getValues());
+        self::assertSame($filteredArray, $baseInputFilter->getRawValues());
     }
 
     public function addMethodArgumentsProvider()

--- a/test/CollectionInputFilterTest.php
+++ b/test/CollectionInputFilterTest.php
@@ -765,4 +765,35 @@ class CollectionInputFilterTest extends TestCase
             [NotEmpty::IS_EMPTY => $message],
         ], $this->inputFilter->getMessages());
     }
+
+    public function testSetDataUsingSetDataAndRunningIsValidReturningSameAsOriginalForUnfilteredData()
+    {
+        $filteredArray = [
+            [
+                'bar' => 'foo',
+                'foo' => 'bar',
+            ],
+        ];
+
+        $unfilteredArray = array_merge(
+            $filteredArray,
+            [
+                [
+                    'foo' => 'bar',
+                ],
+            ]
+        );
+
+        /** @var BaseInputFilter $baseInputFilter */
+        $baseInputFilter = (new BaseInputFilter())
+            ->add(new Input(), 'bar');
+
+        /** @var CollectionInputFilter $collectionInputFilter */
+        $collectionInputFilter = (new CollectionInputFilter())->setInputFilter($baseInputFilter);
+        $collectionInputFilter->setData($unfilteredArray);
+
+        $collectionInputFilter->isValid();
+
+        self::assertSame($unfilteredArray, $collectionInputFilter->getUnfilteredData());
+    }
 }


### PR DESCRIPTION
Based on old PR (deprecated) discussion [here](https://github.com/zendframework/zend-inputfilter/pull/169) and Issue description [here](https://github.com/zendframework/zend-inputfilter/issues/168)

[Link to last comment](https://github.com/zendframework/zend-inputfilter/pull/169#issuecomment-447769290) with action points (copied below)

---

@froschdesign @svycka @weierophinney

I haven't forgotten this, just didn't have time this weekend. I hope to get to it this week either during work, an evening or maybe during the coming weekend. However, very busy at the moment.

What I'll try to do the coming days:

Setup up a skeleton application demonstrating issue with plain modules, comments, etc.
Summarize this thread & #168 into a coherent whole
Quick re-read though:

getRawValue(s)() should not be altered from existing functionality to prevent bc-break
Agreed with that getRawValue(s)() returns only known input values, UnfilteredDataInterface should provide solution next to these functions
UnfilteredDataInterface adds functionality instead of modifying existing ones
I'll get into that more by providing the code I mentioned with unit testing - I hope this can wait a few more days (possibly weeks). Like I said, currently very busy, also next to my job. Though holidays soon, so might get something done then...

---

**So I think this might be it**

I've done this one TDD (pats own back). I'm however running stretched for time, so I'm hoping to get some feedback for now. 

Also, starting a new job next month in Symfony development (my own projects run ZF3/Doctrine), so as I'll have to do some study to get up to speed, ZF3 contributions will regrettably have to go on a back-burner. 