### PR TITLE
Add validator's priority retrieval into Factory

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -425,7 +425,11 @@ class Factory
                 if (isset($validator['break_chain_on_failure'])) {
                     $breakChainOnFailure = $validator['break_chain_on_failure'];
                 }
-                $chain->attachByName($name, $options, $breakChainOnFailure);
+                $priority = ValidatorChain::DEFAULT_PRIORITY;
+                if (isset($validator['priority'])) {
+                    $priority = $validator['priority'];
+                }
+                $chain->attachByName($name, $options, $breakChainOnFailure, $priority);
                 continue;
             }
 

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -425,10 +425,7 @@ class Factory
                 if (isset($validator['break_chain_on_failure'])) {
                     $breakChainOnFailure = $validator['break_chain_on_failure'];
                 }
-                $priority = ValidatorChain::DEFAULT_PRIORITY;
-                if (isset($validator['priority'])) {
-                    $priority = $validator['priority'];
-                }
+                $priority = isset($validator['priority']) ? $validator['priority'] : ValidatorChain::DEFAULT_PRIORITY;
                 $chain->attachByName($name, $options, $breakChainOnFailure, $priority);
                 continue;
             }

--- a/test/FactoryTest.php
+++ b/test/FactoryTest.php
@@ -726,6 +726,62 @@ class FactoryTest extends TestCase
             }
             $index++;
         }
+
+        $this->assertSame(3, $index);
+    }
+
+    public function testFactoryValidatorsPriority()
+    {
+        $order = 0;
+
+        //Reminder: Priority at which to enqueue validator; defaults to 1 (higher executes earlier)
+        $factory = $this->createDefaultFactory();
+        $input   = $factory->createInput([
+            'name'       => 'foo',
+            'validators' => [
+                [
+                    'name'     => 'Callback',
+                    'priority' => Validator\ValidatorChain::DEFAULT_PRIORITY - 1, // 0
+                    'options' => [
+                        'callback' => static function ($value) use (&$order) {
+                            static::assertSame(2, $order);
+                            ++$order;
+
+                            return true;
+                        },
+                    ],
+                ],
+                [
+                    'name'     => 'Callback',
+                    'priority' => Validator\ValidatorChain::DEFAULT_PRIORITY + 1, // 2
+                    'options'  => [
+                        'callback' => static function ($value) use (&$order) {
+                            static::assertSame(0, $order);
+                            ++$order;
+
+                            return true;
+                        },
+                    ],
+                ],
+                [
+                    'name'     => 'Callback', // default priority 1
+                    'options'  => [
+                        'callback' => static function ($value) use (&$order) {
+                            static::assertSame(1, $order);
+                            ++$order;
+
+                            return true;
+                        },
+                    ],
+                ],
+            ],
+        ]);
+
+        // We should have 3 validators
+        $this->assertEquals(3, $input->getValidatorChain()->count());
+
+        $input->setValue(['foo' => false]);
+        self::assertTrue($input->isValid());
     }
 
     public function testConflictNameWithInputFilterType()
@@ -1068,9 +1124,7 @@ class FactoryTest extends TestCase
      */
     protected function createDefaultFactory()
     {
-        $factory = new Factory();
-
-        return $factory;
+        return new Factory();
     }
 
     /**

--- a/test/FactoryTest.php
+++ b/test/FactoryTest.php
@@ -407,7 +407,8 @@ class FactoryTest extends TestCase
         $this->assertEquals('foo', $input->getName());
         $chain = $input->getValidatorChain();
         $index = 0;
-        foreach ($chain as $validator) {
+        foreach ($chain->getValidators() as $validator) {
+            $validator = $validator['instance'];
             switch ($index) {
                 case 0:
                     $this->assertInstanceOf(Validator\NotEmpty::class, $validator);
@@ -425,6 +426,8 @@ class FactoryTest extends TestCase
             }
             $index++;
         }
+        // Assure that previous foreach has been run
+        $this->assertEquals(3, $index);
     }
 
     public function testFactoryWillCreateInputWithSuggestedRequiredFlagAndAlternativeAllowEmptyFlag()


### PR DESCRIPTION
I noticed that it was impossible to set validator's priority using the "array notation", even if this feature was already there as it already exists for filters (see line 384 of Factory.php).

To add the priority, it will be enough to add the `priority` key in the array:
```php
$inputFilter[] = [
    'name' => 'text_elt',
    'required' => true,
    'filters' => [
        ['name' => 'StripTags'],
        ['name' => 'StringTrim']
    ],
    'validators' => [
        [
            'name' => 'StringLength',
            'options' => [
                'max' => 256
            ],
            'priority' => 2
        ]
    ]
];
```

### FactoryTest fix
I also noticed that the FactoryTest class had a minor issue, which was that validators where not tested inside the `testFactoryWillCreateInputWithSuggestedValidators` method. 
I fixed the loop and added a final assert to verify that all the validators have been tested.